### PR TITLE
chore: migrate repository to AlertLens GitHub organization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/gaetanars/alertlens
+          images: ghcr.io/alertlens/alertlens
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ dist/                          — compiled frontend (git-ignored, produced by `
 | Trigger | Workflow | Action |
 |---|---|---|
 | Push / PR to `main` | `ci.yml` | `go vet` + `go test -race` + build check |
-| Tag `v*` | `release.yml` | 5 cross-compiled binaries + multi-arch Docker image (`ghcr.io/gaetanars/alertlens`) |
+| Tag `v*` | `release.yml` | 5 cross-compiled binaries + multi-arch Docker image (`ghcr.io/alertlens/alertlens`) |
 | Push to `main` or tag `v*` | `docs.yml` | MkDocs Material → GitHub Pages (mike versioning) |
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 **A modern UI for Prometheus Alertmanager — visualize, silence, and manage configurations with ease.**
 
-[![CI](https://github.com/gaetanars/AlertLens/actions/workflows/ci.yml/badge.svg)](https://github.com/gaetanars/AlertLens/actions/workflows/ci.yml)
-[![Docker](https://img.shields.io/badge/Docker-ghcr.io%2Fgaetanars%2Falertlens-blue?logo=docker)](https://github.com/gaetanars/AlertLens/pkgs/container/alertlens)
+[![CI](https://github.com/AlertLens/AlertLens/actions/workflows/ci.yml/badge.svg)](https://github.com/AlertLens/AlertLens/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/badge/Docker-ghcr.io%2Falertlens%2Falertlens-blue?logo=docker)](https://github.com/AlertLens/AlertLens/pkgs/container/alertlens)
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go)](https://golang.org)
-[![License](https://img.shields.io/github/license/gaetanars/AlertLens)](LICENSE)
-[![Docs](https://img.shields.io/badge/Docs-gaetanars.github.io%2FAlertLens-orange)](https://gaetanars.github.io/AlertLens/)
+[![License](https://img.shields.io/github/license/AlertLens/AlertLens)](LICENSE)
+[![Docs](https://img.shields.io/badge/Docs-alertlens.github.io%2FAlertLens-orange)](https://alertlens.github.io/AlertLens/)
 
 </div>
 
@@ -41,14 +41,14 @@ docker run -d \
   --name alertlens \
   -p 9000:9000 \
   -e ALERTLENS_ALERTMANAGERS_0_URL=http://alertmanager:9093 \
-  ghcr.io/gaetanars/alertlens:latest
+  ghcr.io/alertlens/alertlens:latest
 ```
 
 Open [http://localhost:9000](http://localhost:9000).
 
 ### Binary
 
-Download the latest binary from the [Releases](https://github.com/gaetanars/AlertLens/releases) page, then:
+Download the latest binary from the [Releases](https://github.com/AlertLens/AlertLens/releases) page, then:
 
 ```bash
 ./alertlens -config alertlens.yaml
@@ -110,7 +110,7 @@ Before any write, AlertLens shows a unified diff. You confirm — then the chang
 Requires Go 1.25+ and Node.js 20+.
 
 ```bash
-git clone https://github.com/gaetanars/AlertLens.git
+git clone https://github.com/AlertLens/AlertLens.git
 cd AlertLens
 make build
 ./alertlens -config alertlens.yaml
@@ -118,12 +118,12 @@ make build
 
 ## Documentation
 
-Full documentation at **[gaetanars.github.io/AlertLens](https://gaetanars.github.io/AlertLens/)**.
+Full documentation at **[alertlens.github.io/AlertLens](https://alertlens.github.io/AlertLens/)**.
 
-- [Getting Started](https://gaetanars.github.io/AlertLens/getting-started/)
-- [Configuration Reference](https://gaetanars.github.io/AlertLens/configuration/)
-- [Docker Deployment](https://gaetanars.github.io/AlertLens/deployment/docker/)
-- [Configuration Builder](https://gaetanars.github.io/AlertLens/features/config-builder/)
+- [Getting Started](https://alertlens.github.io/AlertLens/getting-started/)
+- [Configuration Reference](https://alertlens.github.io/AlertLens/configuration/)
+- [Docker Deployment](https://alertlens.github.io/AlertLens/deployment/docker/)
+- [Configuration Builder](https://alertlens.github.io/AlertLens/features/config-builder/)
 
 ## Architecture
 

--- a/chart/alertlens/Chart.yaml
+++ b/chart/alertlens/Chart.yaml
@@ -5,10 +5,10 @@ type: application
 version: 0.1.0
 appVersion: "0.1.0"
 
-home: https://github.com/gaetanars/AlertLens
+home: https://github.com/AlertLens/AlertLens
 sources:
-  - https://github.com/gaetanars/AlertLens
-icon: https://raw.githubusercontent.com/gaetanars/AlertLens/main/web/static/favicon.png
+  - https://github.com/AlertLens/AlertLens
+icon: https://raw.githubusercontent.com/AlertLens/AlertLens/main/web/static/favicon.png
 
 keywords:
   - alertmanager
@@ -19,18 +19,18 @@ keywords:
   - observability
 
 maintainers:
-  - name: gaetanars
-    url: https://github.com/gaetanars
+  - name: AlertLens
+    url: https://github.com/AlertLens
 
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/links: |
     - name: Documentation
-      url: https://gaetanars.github.io/AlertLens/
+      url: https://alertlens.github.io/AlertLens/
     - name: GitHub
-      url: https://github.com/gaetanars/AlertLens
+      url: https://github.com/AlertLens/AlertLens
     - name: Docker image
-      url: https://github.com/gaetanars/AlertLens/pkgs/container/alertlens
+      url: https://github.com/AlertLens/AlertLens/pkgs/container/alertlens
   artifacthub.io/changes: |
     - kind: added
       description: Initial release of AlertLens Helm chart

--- a/chart/alertlens/README.md
+++ b/chart/alertlens/README.md
@@ -5,13 +5,13 @@ A modern UI for Prometheus Alertmanager — visualize, silence, and manage confi
 ## TL;DR
 
 ```bash
-helm install alertlens oci://ghcr.io/gaetanars/chart/alertlens \
+helm install alertlens oci://ghcr.io/alertlens/chart/alertlens \
   --set alertlens.alertmanagers[0].url=http://alertmanager:9093
 ```
 
 ## Introduction
 
-This chart deploys [AlertLens](https://github.com/gaetanars/AlertLens) on a Kubernetes cluster.
+This chart deploys [AlertLens](https://github.com/AlertLens/AlertLens) on a Kubernetes cluster.
 
 AlertLens is a **stateless** single binary — all state lives in Alertmanager. The chart deploys:
 
@@ -31,11 +31,11 @@ AlertLens is a **stateless** single binary — all state lives in Alertmanager. 
 
 ```bash
 # Minimal — read-only mode, no admin password
-helm install alertlens oci://ghcr.io/gaetanars/chart/alertlens \
+helm install alertlens oci://ghcr.io/alertlens/chart/alertlens \
   --set alertlens.alertmanagers[0].url=http://alertmanager.monitoring:9093
 
 # With admin password (enables silence creation and config editing)
-helm install alertlens oci://ghcr.io/gaetanars/chart/alertlens \
+helm install alertlens oci://ghcr.io/alertlens/chart/alertlens \
   --set alertlens.alertmanagers[0].url=http://alertmanager.monitoring:9093 \
   --set alertlens.adminPassword=my-strong-password
 ```
@@ -43,7 +43,7 @@ helm install alertlens oci://ghcr.io/gaetanars/chart/alertlens \
 Or with a `values.yaml` file:
 
 ```bash
-helm install alertlens oci://ghcr.io/gaetanars/chart/alertlens -f values.yaml
+helm install alertlens oci://ghcr.io/alertlens/chart/alertlens -f values.yaml
 ```
 
 ## Uninstalling the chart
@@ -178,7 +178,7 @@ autoscaling:
 
 | Parameter | Description | Default |
 |---|---|---|
-| `image.repository` | Image repository | `ghcr.io/gaetanars/alertlens` |
+| `image.repository` | Image repository | `ghcr.io/alertlens/alertlens` |
 | `image.tag` | Image tag (defaults to chart AppVersion) | `""` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Image pull secrets | `[]` |
@@ -264,9 +264,9 @@ The chart follows Kubernetes security best practices out of the box:
 
 ## Source code
 
-- [AlertLens](https://github.com/gaetanars/AlertLens)
-- [Helm chart](https://github.com/gaetanars/AlertLens/tree/main/chart/alertlens)
+- [AlertLens](https://github.com/AlertLens/AlertLens)
+- [Helm chart](https://github.com/AlertLens/AlertLens/tree/main/chart/alertlens)
 
 ## License
 
-[Apache 2.0](https://github.com/gaetanars/AlertLens/blob/main/LICENSE)
+[Apache 2.0](https://github.com/AlertLens/AlertLens/blob/main/LICENSE)

--- a/chart/alertlens/values.yaml
+++ b/chart/alertlens/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/gaetanars/alertlens
+  repository: ghcr.io/alertlens/alertlens
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart AppVersion.
   tag: ""

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,9 +9,21 @@ AlertLens uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+---
+
+## [v0.2.0] — 2026-03-07
+
+### Changed
+
+- Project moved to the **AlertLens** GitHub organization (`github.com/AlertLens/AlertLens`).
+- Go module path updated from `github.com/gaetanars/alertlens` to `github.com/alertlens/alertlens`.
+- Docker image renamed from `ghcr.io/gaetanars/alertlens` to `ghcr.io/alertlens/alertlens`.
+- Helm OCI chart path updated from `ghcr.io/gaetanars/chart/alertlens` to `ghcr.io/alertlens/chart/alertlens`.
+- Documentation site moved from `gaetanars.github.io/AlertLens` to `alertlens.github.io/AlertLens`.
+
 ### Fixed
 
-- Helm chart OCI registry path corrected from `ghcr.io/gaetanars/charts/alertlens` to `ghcr.io/gaetanars/chart/alertlens` in the release workflow, chart README, and Kubernetes deployment documentation.
+- Helm chart OCI registry path corrected from `ghcr.io/alertlens/charts/alertlens` to `ghcr.io/alertlens/chart/alertlens` in the release workflow, chart README, and Kubernetes deployment documentation.
 
 ---
 

--- a/docs/deployment/binary.md
+++ b/docs/deployment/binary.md
@@ -2,12 +2,12 @@
 
 ## Download a Pre-built Binary
 
-Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Releases](https://github.com/gaetanars/AlertLens/releases) page.
+Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Releases](https://github.com/AlertLens/AlertLens/releases) page.
 
 === "Linux (amd64)"
 
     ```bash
-    curl -LO https://github.com/gaetanars/AlertLens/releases/latest/download/alertlens-linux-amd64
+    curl -LO https://github.com/AlertLens/AlertLens/releases/latest/download/alertlens-linux-amd64
     chmod +x alertlens-linux-amd64
     sudo mv alertlens-linux-amd64 /usr/local/bin/alertlens
     ```
@@ -15,7 +15,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
 === "Linux (arm64)"
 
     ```bash
-    curl -LO https://github.com/gaetanars/AlertLens/releases/latest/download/alertlens-linux-arm64
+    curl -LO https://github.com/AlertLens/AlertLens/releases/latest/download/alertlens-linux-arm64
     chmod +x alertlens-linux-arm64
     sudo mv alertlens-linux-arm64 /usr/local/bin/alertlens
     ```
@@ -23,7 +23,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
 === "macOS (arm64)"
 
     ```bash
-    curl -LO https://github.com/gaetanars/AlertLens/releases/latest/download/alertlens-darwin-arm64
+    curl -LO https://github.com/AlertLens/AlertLens/releases/latest/download/alertlens-darwin-arm64
     chmod +x alertlens-darwin-arm64
     sudo mv alertlens-darwin-arm64 /usr/local/bin/alertlens
     ```
@@ -44,7 +44,7 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub Re
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/gaetanars/AlertLens.git
+git clone https://github.com/AlertLens/AlertLens.git
 cd AlertLens
 
 # 2. Build frontend + backend (one command)

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -13,7 +13,7 @@ docker run -d \
   -e ALERTLENS_AUTH_ADMIN_PASSWORD="your-strong-password" \
   -e ALERTLENS_ALERTMANAGERS_0_URL="http://alertmanager:9093" \
   --restart unless-stopped \
-  ghcr.io/gaetanars/alertlens:latest
+  ghcr.io/alertlens/alertlens:latest
 ```
 
 ---
@@ -41,7 +41,7 @@ docker run -d \
   --name alertlens \
   -p 9000:9000 \
   -v $(pwd)/alertlens.yaml:/etc/alertlens/alertlens.yaml:ro \
-  ghcr.io/gaetanars/alertlens:latest \
+  ghcr.io/alertlens/alertlens:latest \
   -config /etc/alertlens/alertlens.yaml
 ```
 
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
 
   alertlens:
-    image: ghcr.io/gaetanars/alertlens:latest
+    image: ghcr.io/alertlens/alertlens:latest
     command: [-config, /etc/alertlens/alertlens.yaml]
     volumes:
       - ./alertlens.yaml:/etc/alertlens/alertlens.yaml:ro

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -18,7 +18,7 @@ AlertLens ships an official Helm chart published to the GitHub Container Registr
 
     ```bash
     helm install alertlens \
-      oci://ghcr.io/gaetanars/chart/alertlens \
+      oci://ghcr.io/alertlens/chart/alertlens \
       --set alertlens.alertmanagers[0].url=http://alertmanager.monitoring:9093
     ```
 
@@ -28,7 +28,7 @@ AlertLens ships an official Helm chart published to the GitHub Container Registr
 
     ```bash
     helm install alertlens \
-      oci://ghcr.io/gaetanars/chart/alertlens \
+      oci://ghcr.io/alertlens/chart/alertlens \
       --set alertlens.alertmanagers[0].url=http://alertmanager.monitoring:9093 \
       --set alertlens.adminPassword=your-strong-password
     ```
@@ -37,7 +37,7 @@ AlertLens ships an official Helm chart published to the GitHub Container Registr
 
     ```bash
     helm install alertlens \
-      oci://ghcr.io/gaetanars/chart/alertlens \
+      oci://ghcr.io/alertlens/chart/alertlens \
       -f alertlens-values.yaml
     ```
 
@@ -195,7 +195,7 @@ topologySpreadConstraints:
 ## Upgrading
 
 ```bash
-helm upgrade alertlens oci://ghcr.io/gaetanars/chart/alertlens \
+helm upgrade alertlens oci://ghcr.io/alertlens/chart/alertlens \
   --reuse-values \
   --version 0.2.0
 ```
@@ -230,8 +230,8 @@ The chart enforces Kubernetes security best practices out of the box:
 
 ## Full values reference
 
-See the [chart README](https://github.com/gaetanars/AlertLens/blob/main/chart/alertlens/README.md) or run:
+See the [chart README](https://github.com/AlertLens/AlertLens/blob/main/chart/alertlens/README.md) or run:
 
 ```bash
-helm show values oci://ghcr.io/gaetanars/chart/alertlens
+helm show values oci://ghcr.io/alertlens/chart/alertlens
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@
       --name alertlens \
       -p 9000:9000 \
       -v $(pwd)/alertlens.yaml:/etc/alertlens/alertlens.yaml:ro \
-      ghcr.io/gaetanars/alertlens:latest \
+      ghcr.io/alertlens/alertlens:latest \
       -config /etc/alertlens/alertlens.yaml
     ```
 
@@ -26,11 +26,11 @@
 
 === "Pre-built binary"
 
-    Download the latest binary from the [GitHub Releases](https://github.com/gaetanars/AlertLens/releases) page:
+    Download the latest binary from the [GitHub Releases](https://github.com/AlertLens/AlertLens/releases) page:
 
     ```bash
     # Linux amd64
-    curl -LO https://github.com/gaetanars/AlertLens/releases/latest/download/alertlens-linux-amd64
+    curl -LO https://github.com/AlertLens/AlertLens/releases/latest/download/alertlens-linux-amd64
     chmod +x alertlens-linux-amd64
     ./alertlens-linux-amd64 -config alertlens.yaml
     ```
@@ -40,7 +40,7 @@
     Requires Go 1.25+ and Node.js 20+.
 
     ```bash
-    git clone https://github.com/gaetanars/AlertLens.git
+    git clone https://github.com/AlertLens/AlertLens.git
     cd AlertLens
     make build
     ./alertlens -config alertlens.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Unlike read-only dashboards, AlertLens lets you **understand, visualize, and act
     ```bash
     docker run -p 9000:9000 \
       -e ALERTLENS_ALERTMANAGERS_0_URL=http://alertmanager:9093 \
-      ghcr.io/gaetanars/alertlens:latest
+      ghcr.io/alertlens/alertlens:latest
     ```
 
 === "Binary"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gaetanars/alertlens
+module github.com/alertlens/alertlens
 
 go 1.25
 

--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gaetanars/alertlens/internal/config"
+	"github.com/alertlens/alertlens/internal/config"
 )
 
 const (

--- a/internal/alertmanager/pool.go
+++ b/internal/alertmanager/pool.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"sync"
 
-	"github.com/gaetanars/alertlens/internal/config"
+	"github.com/alertlens/alertlens/internal/config"
 	"go.uber.org/zap"
 )
 

--- a/internal/api/handlers/alertmanagers.go
+++ b/internal/api/handlers/alertmanagers.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/alertmanager"
 )
 
 // AlertmanagersHandler handles requests about AM instances.

--- a/internal/api/handlers/alerts.go
+++ b/internal/api/handlers/alerts.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/alertmanager"
 )
 
 // AlertsHandler handles alert-related requests.

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gaetanars/alertlens/internal/auth"
+	"github.com/alertlens/alertlens/internal/auth"
 )
 
 // AuthHandler holds the auth service for HTTP handler use.

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gaetanars/alertlens/internal/auth"
+	"github.com/alertlens/alertlens/internal/auth"
 )
 
 // ─── helpers ──────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
-	"github.com/gaetanars/alertlens/internal/configbuilder"
-	"github.com/gaetanars/alertlens/internal/gitops"
+	"github.com/alertlens/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/configbuilder"
+	"github.com/alertlens/alertlens/internal/gitops"
 )
 
 // ConfigHandler handles configuration builder requests.

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"net/http"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/alertmanager"
 )
 
 // resolveClient returns the named alertmanager client, or the first available

--- a/internal/api/handlers/routing.go
+++ b/internal/api/handlers/routing.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/alertmanager"
 	amconfig "github.com/prometheus/alertmanager/config"
 	"gopkg.in/yaml.v3"
 )

--- a/internal/api/handlers/silences.go
+++ b/internal/api/handlers/silences.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/gaetanars/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/alertmanager"
 )
 
 // SilencesHandler handles silence-related requests.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -8,10 +8,10 @@ import (
 	"github.com/go-chi/cors"
 	"go.uber.org/zap"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
-	"github.com/gaetanars/alertlens/internal/api/handlers"
-	"github.com/gaetanars/alertlens/internal/auth"
-	"github.com/gaetanars/alertlens/internal/gitops"
+	"github.com/alertlens/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/api/handlers"
+	"github.com/alertlens/alertlens/internal/auth"
+	"github.com/alertlens/alertlens/internal/gitops"
 )
 
 // maxRequestBodyBytes is the hard cap on incoming request bodies (10 MiB).

--- a/main.go
+++ b/main.go
@@ -14,11 +14,11 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/gaetanars/alertlens/internal/alertmanager"
-	"github.com/gaetanars/alertlens/internal/api"
-	"github.com/gaetanars/alertlens/internal/auth"
-	"github.com/gaetanars/alertlens/internal/config"
-	"github.com/gaetanars/alertlens/internal/gitops"
+	"github.com/alertlens/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/api"
+	"github.com/alertlens/alertlens/internal/auth"
+	"github.com/alertlens/alertlens/internal/config"
+	"github.com/alertlens/alertlens/internal/gitops"
 )
 
 // version is injected at build time via -ldflags.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
 site_name: AlertLens
 site_description: A modern UI for Alertmanager — visualize, silence, and manage configurations with ease.
 site_author: Gaetan ARS
-site_url: https://gaetanars.github.io/AlertLens/
-repo_name: gaetanars/AlertLens
-repo_url: https://github.com/gaetanars/AlertLens
+site_url: https://alertlens.github.io/AlertLens/
+repo_name: AlertLens/AlertLens
+repo_url: https://github.com/AlertLens/AlertLens
 edit_uri: edit/main/docs/
 
 theme:
@@ -45,7 +45,7 @@ extra:
     default: stable
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/gaetanars/AlertLens
+      link: https://github.com/AlertLens/AlertLens
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

- Go module path renamed from `github.com/gaetanars/alertlens` to `github.com/alertlens/alertlens` (all Go source files + `go.mod`)
- Docker image renamed from `ghcr.io/gaetanars/alertlens` to `ghcr.io/alertlens/alertlens`
- Helm OCI chart path updated from `ghcr.io/gaetanars/chart/alertlens` to `ghcr.io/alertlens/chart/alertlens`
- All GitHub URLs updated to `github.com/AlertLens/AlertLens` across README, docs, chart, and CI workflow
- Docs site URL updated to `alertlens.github.io/AlertLens`
- `chart/alertlens/Chart.yaml` maintainer updated to AlertLens org
- Changelog updated with v0.2.0 entry documenting the migration

## Test plan

- [x] CI passes (go vet + go test)
- [x] Build check passes (frontend + Go binary)
- [x] After merge: create tag `v0.2.0` to trigger the release workflow