### PR TITLE
ci(release): lowercase repository owner before helm OCI push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,5 +219,6 @@ jobs:
 
       - name: Push Helm chart to GHCR
         run: |
+          OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           helm push "alertlens-${{ env.CHART_VERSION }}.tgz" \
-            oci://ghcr.io/${{ github.repository_owner }}/chart
+            oci://ghcr.io/${OWNER}/chart


### PR DESCRIPTION
github.repository_owner returns the org name as-is (e.g. AlertLens), but OCI registry references require all-lowercase paths. Lowercasing via tr fixes the invalid_reference error on helm push.