### PR TITLE
fix(csp): inject SvelteKit inline-script hash to unblock SPA rendering

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -20,23 +20,34 @@ import (
 // trivial OOM attacks while leaving plenty of headroom.
 const maxRequestBodyBytes = 10 << 20 // 10 MiB
 
-// cspPolicy is the Content-Security-Policy header value applied to every
-// response.  It prevents XSS exploitation even if an attacker finds a
-// reflection point, by:
-//   - Restricting scripts to same-origin only (no inline, no CDN).
-//   - Allowing inline styles (required by SvelteKit / Tailwind).
-//   - Blocking <object>, <embed> and <frame*> entirely.
-//   - Pinning base-uri and form-action to 'self'.
-const cspPolicy = "default-src 'self'; " +
-	"script-src 'self'; " +
-	"style-src 'self' 'unsafe-inline'; " +
-	"img-src 'self' data: blob:; " +
-	"font-src 'self'; " +
-	"connect-src 'self'; " +
-	"object-src 'none'; " +
-	"base-uri 'self'; " +
-	"form-action 'self'; " +
-	"frame-ancestors 'none';"
+// buildCSPPolicy constructs the Content-Security-Policy header value.
+//
+// scriptHashes is a space-separated list of 'sha256-<base64>' tokens for any
+// inline scripts that must be allowed (e.g. SvelteKit's bootstrapper).  When
+// empty, script-src falls back to 'self' only — which is correct for API-only
+// responses but will block the SPA in a browser.
+//
+// The policy:
+//   - Restricts scripts to same-origin plus the supplied hashes (no unsafe-inline).
+//   - Allows inline styles (required by SvelteKit / Tailwind).
+//   - Blocks <object>, <embed> and <frame*> entirely.
+//   - Pins base-uri and form-action to 'self'.
+func buildCSPPolicy(scriptHashes string) string {
+	scriptSrc := "'self'"
+	if scriptHashes != "" {
+		scriptSrc += " " + scriptHashes
+	}
+	return "default-src 'self'; " +
+		"script-src " + scriptSrc + "; " +
+		"style-src 'self' 'unsafe-inline'; " +
+		"img-src 'self' data: blob:; " +
+		"font-src 'self'; " +
+		"connect-src 'self'; " +
+		"object-src 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'; " +
+		"frame-ancestors 'none';"
+}
 
 // NewRouter wires all API routes and returns the root http.Handler.
 // The frontendFS is served for all non-API routes (SPA fallback).
@@ -44,6 +55,9 @@ const cspPolicy = "default-src 'self'; " +
 // corresponding forge is not configured, so interface nil-checks in handlers work.
 // secureCookies controls the Secure attribute on the CSRF cookie; set to true
 // when the application is served behind HTTPS.
+// scriptHashes is the space-separated list of 'sha256-<base64>' tokens for the
+// inline scripts present in dist/index.html (produced by the Vite csp-hash
+// plugin).  Pass an empty string when no inline scripts are present.
 func NewRouter(
 	pool *alertmanager.Pool,
 	authSvc *auth.Service,
@@ -55,6 +69,7 @@ func NewRouter(
 	version string,
 	logger *zap.Logger,
 	incidentStore *incident.Store,
+	scriptHashes string,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -82,7 +97,13 @@ func NewRouter(
 		})
 	})
 	// SEC-CSP: Content-Security-Policy to prevent XSS exploitation.
-	r.Use(cspMiddleware)
+	// The policy is built at router-construction time so the inline-script
+	// hash from dist/csp-hash.txt is captured in the closure without any
+	// per-request overhead.
+	cspPolicy := buildCSPPolicy(scriptHashes)
+	r.Use(func(next http.Handler) http.Handler {
+		return cspMiddlewareWithPolicy(cspPolicy, next)
+	})
 	// SEC-CSRF: Double-submit cookie CSRF protection.
 	r.Use(auth.CSRFMiddleware(csrfSecret, secureCookies))
 	r.Use(cors.Handler(cors.Options{
@@ -200,11 +221,11 @@ func NewRouter(
 	return r
 }
 
-// cspMiddleware sets the Content-Security-Policy and related security headers
-// on every HTTP response.
-func cspMiddleware(next http.Handler) http.Handler {
+// cspMiddlewareWithPolicy sets the Content-Security-Policy and related security
+// headers on every HTTP response using the supplied policy string.
+func cspMiddlewareWithPolicy(policy string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", cspPolicy)
+		w.Header().Set("Content-Security-Policy", policy)
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ─── buildCSPPolicy ───────────────────────────────────────────────────────────
+
+func TestBuildCSPPolicy_NoHashes(t *testing.T) {
+	policy := buildCSPPolicy("")
+
+	// script-src must be 'self' only — no unsafe-inline, no hashes.
+	scriptSrc := extractDirective(policy, "script-src")
+	if scriptSrc == "" {
+		t.Fatal("script-src directive missing from CSP policy")
+	}
+	if !strings.Contains(scriptSrc, "'self'") {
+		t.Errorf("expected script-src to contain 'self', got: %q", scriptSrc)
+	}
+	if strings.Contains(scriptSrc, "'unsafe-inline'") {
+		t.Errorf("script-src must not contain 'unsafe-inline', got: %q", scriptSrc)
+	}
+	if strings.Contains(scriptSrc, "sha256-") {
+		t.Errorf("script-src should not contain a hash when none was provided, got: %q", scriptSrc)
+	}
+}
+
+func TestBuildCSPPolicy_WithSingleHash(t *testing.T) {
+	hash := "'sha256-sT2qA9cf7BKsSdySbq8RHggzSGve/KytHCRr70CnQxY='"
+	policy := buildCSPPolicy(hash)
+
+	scriptSrc := extractDirective(policy, "script-src")
+	if !strings.Contains(scriptSrc, "'self'") {
+		t.Errorf("expected script-src to contain 'self', got: %q", scriptSrc)
+	}
+	if !strings.Contains(scriptSrc, hash) {
+		t.Errorf("expected script-src to contain the supplied hash, got: %q", scriptSrc)
+	}
+	if strings.Contains(scriptSrc, "'unsafe-inline'") {
+		t.Errorf("script-src must not contain 'unsafe-inline', got: %q", scriptSrc)
+	}
+}
+
+func TestBuildCSPPolicy_WithMultipleHashes(t *testing.T) {
+	hash1 := "'sha256-aaaa='"
+	hash2 := "'sha256-bbbb='"
+	policy := buildCSPPolicy(hash1 + " " + hash2)
+
+	scriptSrc := extractDirective(policy, "script-src")
+	if !strings.Contains(scriptSrc, hash1) {
+		t.Errorf("expected script-src to contain first hash, got: %q", scriptSrc)
+	}
+	if !strings.Contains(scriptSrc, hash2) {
+		t.Errorf("expected script-src to contain second hash, got: %q", scriptSrc)
+	}
+}
+
+func TestBuildCSPPolicy_OtherDirectivesUnaffected(t *testing.T) {
+	policy := buildCSPPolicy("")
+
+	checks := map[string]string{
+		"default-src":     "'self'",
+		"style-src":       "'unsafe-inline'",
+		"object-src":      "'none'",
+		"frame-ancestors": "'none'",
+		"base-uri":        "'self'",
+		"form-action":     "'self'",
+	}
+
+	for directive, expected := range checks {
+		value := extractDirective(policy, directive)
+		if !strings.Contains(value, expected) {
+			t.Errorf("directive %q: expected %q in %q", directive, expected, value)
+		}
+	}
+}
+
+// ─── cspMiddlewareWithPolicy ──────────────────────────────────────────────────
+
+func TestCSPMiddlewareWithPolicy_SetsHeaders(t *testing.T) {
+	policy := buildCSPPolicy("'sha256-test='")
+
+	handler := cspMiddlewareWithPolicy(policy, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Content-Security-Policy"); got != policy {
+		t.Errorf("Content-Security-Policy header mismatch\n  want: %q\n  got:  %q", policy, got)
+	}
+	if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options: want %q, got %q", "nosniff", got)
+	}
+	if got := rec.Header().Get("X-Frame-Options"); got != "DENY" {
+		t.Errorf("X-Frame-Options: want %q, got %q", "DENY", got)
+	}
+	if got := rec.Header().Get("Referrer-Policy"); got == "" {
+		t.Error("Referrer-Policy header must not be empty")
+	}
+}
+
+func TestCSPMiddlewareWithPolicy_NoUnsafeInlineInScriptSrc(t *testing.T) {
+	// Even when the caller passes an empty hash string, the resulting CSP
+	// header must never advertise 'unsafe-inline' in script-src.
+	policy := buildCSPPolicy("")
+	handler := cspMiddlewareWithPolicy(policy, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	cspHeader := rec.Header().Get("Content-Security-Policy")
+	scriptSrc := extractDirective(cspHeader, "script-src")
+	if strings.Contains(scriptSrc, "'unsafe-inline'") {
+		t.Errorf("script-src must not contain 'unsafe-inline'; CSP: %q", cspHeader)
+	}
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// extractDirective returns the value portion of a CSP directive (e.g.
+// "script-src 'self' 'sha256-xxx'" → "'self' 'sha256-xxx'") or an empty
+// string if the directive is not found.
+func extractDirective(policy, directive string) string {
+	for _, part := range strings.Split(policy, ";") {
+		part = strings.TrimSpace(part)
+		prefix := directive + " "
+		if strings.HasPrefix(part, prefix) {
+			return strings.TrimPrefix(part, prefix)
+		}
+	}
+	return ""
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -101,11 +102,19 @@ func main() {
 	}
 	frontendFS := http.FS(subFS)
 
+	// SEC-CSP: read the inline-script hash(es) produced by the Vite csp-hash
+	// plugin at build time.  The file contains space-separated 'sha256-<base64>'
+	// tokens that are injected into the script-src CSP directive so the browser
+	// can verify and execute SvelteKit's bootstrapper without 'unsafe-inline'.
+	// If the file is absent (e.g. a dev build without the plugin) we fall back
+	// to 'self'-only — the SPA may not render but the server stays secure.
+	scriptHashes := readCSPHashes(subFS, logger)
+
 	// ─── Incident store (in-memory immutable ledger) ─────────────────────────
 	incidentStore := incident.NewStore()
 
 	// ─── HTTP router ─────────────────────────────────────────────────────────
-	router := api.NewRouter(pool, authSvc, ghPusher, glPusher, frontendFS, cfg.Server.CORSAllowedOrigins, cfg.Server.SecureCookies, version, logger, incidentStore)
+	router := api.NewRouter(pool, authSvc, ghPusher, glPusher, frontendFS, cfg.Server.CORSAllowedOrigins, cfg.Server.SecureCookies, version, logger, incidentStore, scriptHashes)
 
 	// ─── HTTP server ─────────────────────────────────────────────────────────
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
@@ -138,4 +147,29 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("server stopped")
+}
+
+// readCSPHashes reads dist/csp-hash.txt from the embedded sub-filesystem and
+// returns its trimmed content — a space-separated list of 'sha256-<base64>'
+// tokens written by the Vite csp-hash plugin after each frontend build.
+//
+// If the file does not exist (e.g. a CI placeholder build without the frontend)
+// an empty string is returned and a warning is logged; the router will then
+// emit a script-src 'self'-only CSP, which keeps the server secure but will
+// prevent the SPA bootstrapper from executing in a real browser.
+func readCSPHashes(subFS fs.FS, logger *zap.Logger) string {
+	data, err := fs.ReadFile(subFS, "csp-hash.txt")
+	if err != nil {
+		logger.Warn("csp-hash.txt not found in embedded dist — SPA inline script will be blocked by CSP",
+			zap.String("hint", "run 'make web-build' or 'npm run build' in the web/ directory"),
+		)
+		return ""
+	}
+	hashes := strings.TrimSpace(string(data))
+	if hashes == "" {
+		logger.Warn("csp-hash.txt is empty — SPA inline script will be blocked by CSP")
+	} else {
+		logger.Info("loaded CSP inline-script hashes", zap.String("hashes", hashes))
+	}
+	return hashes
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,10 +1,75 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath, URL } from 'node:url';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+/**
+ * cspHashPlugin — Vite plugin that runs after the SvelteKit static build.
+ *
+ * SvelteKit's adapter-static always emits an inline bootstrapper <script> in
+ * dist/index.html.  Because that script contains a build-time-generated
+ * identifier (__sveltekit_XXXXXX) the hash changes on every build.
+ *
+ * This plugin:
+ *   1. Reads dist/index.html after the build completes.
+ *   2. Extracts every inline <script> block.
+ *   3. Computes the SHA-256 hash of each block's text content.
+ *   4. Writes the hash(es) as a single line to dist/csp-hash.txt
+ *      in the format expected by the CSP script-src directive:
+ *        'sha256-<base64>' ['sha256-<base64>' …]
+ *
+ * The Go server embeds dist/ and reads csp-hash.txt at startup to construct
+ * the Content-Security-Policy header dynamically, so the hash is always
+ * current without hard-coding it in Go source code.
+ */
+function cspHashPlugin(): Plugin {
+	return {
+		name: 'csp-hash',
+		// closeBundle fires after all output files have been written to disk.
+		closeBundle() {
+			const configDir = dirname(fileURLToPath(import.meta.url));
+			const distDir   = resolve(configDir, '../dist');
+			const htmlPath  = resolve(distDir, 'index.html');
+			const hashPath  = resolve(distDir, 'csp-hash.txt');
+
+			let html: string;
+			try {
+				html = readFileSync(htmlPath, 'utf8');
+			} catch {
+				// During `vite dev` or unit-test runs the dist/ directory may not
+				// exist yet — skip silently so non-build commands are unaffected.
+				return;
+			}
+
+			// Extract the text content of every inline <script> block.
+			// The regex captures everything between <script> and </script> that
+			// does not have a src= attribute (i.e. inline scripts only).
+			const scriptRe = /<script(?![^>]*\bsrc\s*=)[^>]*>([\s\S]*?)<\/script>/gi;
+			const hashes: string[] = [];
+			let match: RegExpExecArray | null;
+
+			while ((match = scriptRe.exec(html)) !== null) {
+				const content = match[1];
+				if (content.trim().length === 0) continue;
+				const digest = createHash('sha256').update(content).digest('base64');
+				hashes.push(`'sha256-${digest}'`);
+			}
+
+			if (hashes.length === 0) {
+				console.warn('[csp-hash] No inline scripts found in dist/index.html — csp-hash.txt will be empty.');
+			}
+
+			writeFileSync(hashPath, hashes.join(' '), 'utf8');
+			console.info(`[csp-hash] Wrote ${hashes.length} hash(es) to dist/csp-hash.txt`);
+		}
+	};
+}
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
+	plugins: [tailwindcss(), sveltekit(), cspHashPlugin()],
 	server: {
 		proxy: {
 			'/api': {


### PR DESCRIPTION
## Summary

- Adds a Vite plugin (`cspHashPlugin`) that computes the SHA-256 hash of SvelteKit's inline bootstrapper script after each build and writes it to `dist/csp-hash.txt`
- The Go server reads `csp-hash.txt` at startup and injects the hash(es) into the `script-src` CSP directive via `buildCSPPolicy()`
- Removes the `'unsafe-inline'` workaround while keeping the SPA fully functional in browsers

## Problem

Commit `b04cc52` removed `'unsafe-inline'` from `script-src` to satisfy the E2E security test. However, SvelteKit's `adapter-static` always emits an inline `<script>` in `dist/index.html`. Without `'unsafe-inline'` or a matching hash, the browser blocks that script and the app renders blank — while the E2E test kept passing because it only checks `/api/health`.

## Solution

The CSP `script-src` directive now includes the exact SHA-256 hash of the current build's bootstrapper:

```
script-src 'self' 'sha256-<base64>'
```

- No `'unsafe-inline'` is ever emitted
- Only the exact script from the current build is trusted
- The hash is regenerated on every `npm run build` — always in sync
- If `csp-hash.txt` is absent (e.g. CI placeholder build), the server logs a warning and falls back to `'self'`-only — secure but SPA won't render

## Test plan

- [x] `go test ./internal/api/...` — 6 new unit tests for `buildCSPPolicy` and `cspMiddlewareWithPolicy`
- [x] `npm run build` in `web/` generates `dist/csp-hash.txt` with a `'sha256-...'` token
- [x] Server starts and logs `loaded CSP inline-script hashes`
- [x] SPA renders correctly in the browser (no blank page)
- [x] E2E security test still passes (`script-src 'self'` is still present in the CSP)
- [x] Browser DevTools confirm no CSP violations

Closes #71