### PR TITLE
ci: publish Docker images to GHCR on release and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   test:
@@ -82,6 +81,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build-and-e2e
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -106,6 +107,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/gaetanars/alertlens:dev
-          build-args: VERSION=dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          build-args: VERSION=dev+${{ github.sha }}
+          cache-from: type=gha,scope=docker-dev
+          cache-to: type=gha,mode=max,scope=docker-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
           files: alertlens-${{ github.ref_name }}-*
 
   docker:
+    name: Publish release image
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -84,8 +86,8 @@ jobs:
         with:
           images: ghcr.io/gaetanars/alertlens
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=semver,pattern=v{{version}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -96,5 +98,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=docker-release
+          cache-to: type=gha,mode=max,scope=docker-release


### PR DESCRIPTION
## Summary

- Adds a `docker` job to `release.yml` that builds and pushes `ghcr.io/gaetanars/alertlens:<semver>` and `ghcr.io/gaetanars/alertlens:latest` on every `v*.*.*` tag push using `docker/metadata-action` for tag derivation
- Adds a `docker-dev` job to `ci.yml` that builds and pushes `ghcr.io/gaetanars/alertlens:dev` on every merge to `main`, gated behind the full test + E2E suite
- Both jobs build for `linux/amd64` and `linux/arm64` using `docker/setup-qemu-action` + `docker/setup-buildx-action`
- `VERSION` build-arg is injected so `alertlens --version` returns the tag name (or `dev` for the edge image)
- GHA layer cache (`type=gha`) keeps subsequent builds fast
- `packages: write` permission added to both workflows to allow pushing to GHCR; the repository is public so the images are publicly pullable without authentication

## Test plan

- [ ] Merge to `main` triggers the `docker-dev` job and `ghcr.io/gaetanars/alertlens:dev` is updated
- [ ] Pushing a `v*.*.*` tag triggers the `docker` job and both `ghcr.io/gaetanars/alertlens:<version>` and `:latest` are updated
- [ ] `docker pull ghcr.io/gaetanars/alertlens:dev` works without authentication
- [ ] `docker run --rm ghcr.io/gaetanars/alertlens:dev --version` returns `dev`
- [ ] Image manifest lists both `linux/amd64` and `linux/arm64` platforms

Closes #62