### PR TITLE
feat(config-builder): save & deploy tab with diff preview, gitops publish, and in-memory history

### DIFF
--- a/docs/features/config-builder.md
+++ b/docs/features/config-builder.md
@@ -72,42 +72,38 @@ All types expose a `send_resolved` toggle to control whether recovery notificati
 
 ---
 
-## Saving Changes
+## Save & Deploy
 
-Before any write, AlertLens shows a **unified diff** of the current vs. proposed configuration. You must confirm before the change is applied.
+The **Save & Deploy** tab is the final step in the build → review → publish workflow. It is always accessible from the Config Builder tab bar, regardless of which editor tab is active.
 
-Two save strategies are available per instance:
+### Diff preview
 
-### Disk Write
+Before saving, AlertLens fetches a unified diff between the current live Alertmanager configuration and the proposed YAML assembled by the builder. The diff is rendered with green/red line highlighting using the existing `YamlDiffViewer` component. If there are no changes, the Save button is disabled and a "No changes" message is shown instead.
 
-AlertLens writes `alertmanager.yml` directly to a file path configured in `config_file_path`.
+### Save modes
 
-```yaml
-alertmanagers:
-  - name: production
-    url: http://alertmanager:9093
-    config_file_path: /etc/alertmanager/alertmanager.yml
-```
+Three save modes are available. Modes whose backend pusher is not configured are shown as disabled with an explanatory tooltip.
 
-An optional **webhook** is called after a successful write (e.g., to trigger a reload or CI pipeline).
+#### Disk
+
+AlertLens writes `alertmanager.yml` directly to the file path you specify.
 
 !!! info "Filesystem access"
     AlertLens must have write access to the file path. In Docker, mount the directory as a volume.
 
-### GitOps Push
+#### GitHub / GitLab
 
-AlertLens commits and pushes the updated `alertmanager.yml` to a GitHub or GitLab repository via the API.
+AlertLens commits and pushes the updated configuration to a Git repository via the forge API. Required fields:
 
-Configurable parameters (set in the UI per instance):
-
-| Parameter | Description |
+| Field | Description |
 |---|---|
-| Repository | `owner/repo` |
+| Repository | `owner/repo` (GitHub) or `namespace/project` (GitLab) |
 | Branch | Target branch (e.g., `main`) |
 | File path | Path inside the repo (e.g., `config/alertmanager.yml`) |
-| Commit message | Template or free text |
+| Commit message | Free text |
+| Author name / email | Commit attribution |
 
-An optional webhook is triggered after the push (e.g., to open a pull request or trigger Argo CD).
+On success, a confirmation banner is shown with a clickable link to the commit on the forge.
 
 Configure tokens in your [AlertLens config](../configuration.md#gitops):
 
@@ -118,6 +114,18 @@ gitops:
   gitlab:
     token: ""   # ALERTLENS_GITOPS_GITLAB_TOKEN
 ```
+
+### Save history
+
+Below the save form, the **Save History** section lists all saves made since the last process restart, newest-first. Each row shows:
+
+- Timestamp (RFC 3339)
+- Save mode badge (disk / github / gitlab)
+- Actor (the role of the user who triggered the save)
+- An **Expand diff** button — clicking it fetches a diff between the saved YAML and the current live config and renders it inline
+
+!!! note "Session-scoped history"
+    Save history is in-memory and resets on process restart. Up to 50 saves are retained per Alertmanager instance (oldest evicted on overflow). Persistent history is tracked in feature 024.
 
 ---
 

--- a/internal/alertmanager/client.go
+++ b/internal/alertmanager/client.go
@@ -62,12 +62,13 @@ const (
 
 // Client is an Alertmanager API v2 client for a single instance.
 type Client struct {
-	name      string
-	baseURL   string
-	tenantID  string
-	userAgent string
-	basicAuth *basicAuthCreds
-	http      *http.Client
+	name           string
+	baseURL        string
+	tenantID       string
+	configFilePath string
+	userAgent      string
+	basicAuth      *basicAuthCreds
+	http           *http.Client
 }
 
 type basicAuthCreds struct {
@@ -88,10 +89,11 @@ func NewClient(cfg config.AlertmanagerConfig, version string) *Client {
 	}
 
 	c := &Client{
-		name:      cfg.Name,
-		baseURL:   strings.TrimRight(cfg.URL, "/"),
-		tenantID:  cfg.TenantID,
-		userAgent: "alertlens/" + version,
+		name:           cfg.Name,
+		baseURL:        strings.TrimRight(cfg.URL, "/"),
+		tenantID:       cfg.TenantID,
+		configFilePath: cfg.ConfigFilePath,
+		userAgent:      "alertlens/" + version,
 		http: &http.Client{
 			Timeout:   15 * time.Second,
 			Transport: transport,
@@ -108,6 +110,10 @@ func NewClient(cfg config.AlertmanagerConfig, version string) *Client {
 
 // Name returns the configured name for this instance.
 func (c *Client) Name() string { return c.name }
+
+// ConfigFilePath returns the local file path configured for disk saves, or an
+// empty string if no path was set for this instance.
+func (c *Client) ConfigFilePath() string { return c.configFilePath }
 
 // GetAlerts fetches alerts from the Alertmanager instance.
 func (c *Client) GetAlerts(ctx context.Context, params AlertsQueryParams) ([]Alert, error) {

--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -8,24 +8,28 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/alertlens/alertlens/internal/alertmanager"
+	"github.com/alertlens/alertlens/internal/auth"
 	"github.com/alertlens/alertlens/internal/configbuilder"
+	"github.com/alertlens/alertlens/internal/confighistory"
 	"github.com/alertlens/alertlens/internal/gitops"
 )
 
 // ConfigHandler handles configuration builder requests.
 type ConfigHandler struct {
 	pool     *alertmanager.Pool
-	ghPusher gitops.Pusher // nil when GitHub is not configured
-	glPusher gitops.Pusher // nil when GitLab is not configured
+	ghPusher gitops.Pusher      // nil when GitHub is not configured
+	glPusher gitops.Pusher      // nil when GitLab is not configured
+	store    *confighistory.Store
 }
 
 // NewConfigHandler creates a ConfigHandler. Pass nil for pushers that are not
 // configured; the interface-nil check in Save is correct only when the caller
 // passes a nil gitops.Pusher (not a typed-nil concrete pointer).
-func NewConfigHandler(pool *alertmanager.Pool, gh, gl gitops.Pusher) *ConfigHandler {
-	return &ConfigHandler{pool: pool, ghPusher: gh, glPusher: gl}
+func NewConfigHandler(pool *alertmanager.Pool, gh, gl gitops.Pusher, store *confighistory.Store) *ConfigHandler {
+	return &ConfigHandler{pool: pool, ghPusher: gh, glPusher: gl, store: store}
 }
 
 // Get handles GET /api/config?instance=<name>.
@@ -206,6 +210,17 @@ func (h *ConfigHandler) Save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Record the successful save in the in-memory history (feature 009).
+	h.store.Append(req.Alertmanager, confighistory.SaveRecord{
+		SavedAt:      time.Now().UTC(),
+		Mode:         req.SaveMode,
+		Alertmanager: req.Alertmanager,
+		Actor:        string(auth.GetRole(r)),
+		CommitSHA:    commitSHA,
+		HTMLURL:      htmlURL,
+		RawYAML:      req.RawYAML,
+	})
+
 	// Trigger optional webhook after save.
 	if req.WebhookURL != "" {
 		// SEC-02: only allow HTTPS webhooks to non-private destinations.
@@ -241,6 +256,34 @@ func (h *ConfigHandler) Save(w http.ResponseWriter, r *http.Request) {
 		"mode":       req.SaveMode,
 		"commit_sha": commitSHA,
 		"html_url":   htmlURL,
+	})
+}
+
+// History handles GET /api/config/history?instance=<name>.
+// Returns an array of save records for the given Alertmanager instance,
+// newest-first. The array is always non-null even when empty.
+func (h *ConfigHandler) History(w http.ResponseWriter, r *http.Request) {
+	instance := r.URL.Query().Get("instance")
+	writeJSON(w, map[string]any{
+		"alertmanager": instance,
+		"history":      h.store.List(instance),
+	})
+}
+
+// GitopsDefaults handles GET /api/config/gitops-defaults?instance=<name>.
+// Returns which GitOps pushers are configured so the frontend can enable or
+// disable the corresponding save modes, and the disk file path for the
+// requested instance so the frontend can pre-fill the disk path field.
+func (h *ConfigHandler) GitopsDefaults(w http.ResponseWriter, r *http.Request) {
+	instance := r.URL.Query().Get("instance")
+	var diskFilePath string
+	if client := h.pool.Client(instance); client != nil {
+		diskFilePath = client.ConfigFilePath()
+	}
+	writeJSON(w, map[string]any{
+		"github_configured": h.ghPusher != nil,
+		"gitlab_configured": h.glPusher != nil,
+		"disk_file_path":    diskFilePath,
 	})
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alertlens/alertlens/internal/alertmanager"
 	"github.com/alertlens/alertlens/internal/api/handlers"
 	"github.com/alertlens/alertlens/internal/auth"
+	"github.com/alertlens/alertlens/internal/confighistory"
 	"github.com/alertlens/alertlens/internal/gitops"
 	"github.com/alertlens/alertlens/internal/incident"
 )
@@ -118,13 +119,15 @@ func NewRouter(
 	}))
 
 	// ─── Instantiate handlers ────────────────────────────────────────────────
+	saveHistory := confighistory.NewStore()
+
 	healthH := handlers.NewHealthHandler(version)
 	authH   := handlers.NewAuthHandler(authSvc)
 	amH     := handlers.NewAlertmanagersHandler(pool)
 	alH     := handlers.NewAlertsHandler(pool)
 	silH    := handlers.NewSilencesHandler(pool)
 	rtH     := handlers.NewRoutingHandler(pool)
-	cfgH    := handlers.NewConfigHandler(pool, ghPusher, glPusher)
+	cfgH    := handlers.NewConfigHandler(pool, ghPusher, glPusher, saveHistory)
 	bulkH   := handlers.NewBulkHandler(pool)
 	bldrH   := handlers.NewBuilderHandler(pool)
 	hubH    := handlers.NewHubHandler(pool, logger)
@@ -172,6 +175,8 @@ func NewRouter(
 		r.With(requireConfigEditor).Post("/config/validate", cfgH.Validate)
 		r.With(requireConfigEditor).Post("/config/diff", cfgH.Diff)
 		r.With(requireConfigEditor).Post("/config/save", cfgH.Save)
+		r.With(requireConfigEditor).Get("/config/history", cfgH.History)
+		r.With(requireConfigEditor).Get("/config/gitops-defaults", cfgH.GitopsDefaults)
 
 		// Structured config builder — CRUD for time intervals, receivers, routes.
 		// All endpoints require config-editor role and return {raw_yaml, validation}.

--- a/internal/confighistory/store.go
+++ b/internal/confighistory/store.go
@@ -1,0 +1,71 @@
+// Package confighistory implements an in-memory, per-instance save history for
+// the Config Builder (feature 009). History resets on process restart.
+package confighistory
+
+import (
+	"sync"
+	"time"
+)
+
+// maxEntriesPerInstance is the maximum number of save records kept per
+// Alertmanager instance. When the limit is exceeded the oldest entry is evicted.
+const maxEntriesPerInstance = 50
+
+// SaveRecord describes a single config save operation.
+type SaveRecord struct {
+	SavedAt      time.Time `json:"saved_at"`
+	Mode         string    `json:"mode"`
+	Alertmanager string    `json:"alertmanager"`
+	Actor        string    `json:"actor"`
+	CommitSHA    string    `json:"commit_sha"`
+	HTMLURL      string    `json:"html_url"`
+	RawYAML      string    `json:"raw_yaml"`
+}
+
+// Store is an in-memory, per-instance save-history ledger. All operations are
+// safe for concurrent use. History is lost on process restart.
+type Store struct {
+	mu      sync.RWMutex
+	entries map[string][]SaveRecord // key = alertmanager instance name
+}
+
+// NewStore creates an empty, ready-to-use Store.
+func NewStore() *Store {
+	return &Store{
+		entries: make(map[string][]SaveRecord),
+	}
+}
+
+// Append records a save operation for the given Alertmanager instance.
+// If the instance already has maxEntriesPerInstance records, the oldest is
+// evicted before the new record is appended.
+func (s *Store) Append(instance string, r SaveRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	list := s.entries[instance]
+	if len(list) >= maxEntriesPerInstance {
+		// Evict the oldest (first) entry.
+		list = list[1:]
+	}
+	s.entries[instance] = append(list, r)
+}
+
+// List returns a copy of the save records for the given instance, ordered
+// newest-first. Returns an empty (non-nil) slice when no records exist.
+func (s *Store) List(instance string) []SaveRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	src := s.entries[instance]
+	if len(src) == 0 {
+		return []SaveRecord{}
+	}
+
+	// Return a reversed copy so the caller always gets newest-first order.
+	out := make([]SaveRecord, len(src))
+	for i, r := range src {
+		out[len(src)-1-i] = r
+	}
+	return out
+}

--- a/internal/confighistory/store_test.go
+++ b/internal/confighistory/store_test.go
@@ -1,0 +1,166 @@
+package confighistory
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func record(mode, instance string) SaveRecord {
+	return SaveRecord{
+		SavedAt:      time.Now(),
+		Mode:         mode,
+		Alertmanager: instance,
+		Actor:        "config-editor",
+	}
+}
+
+func TestStore(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{
+			name: "list on unknown instance returns empty slice",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				got := s.List("nonexistent")
+				if got == nil {
+					t.Fatal("expected non-nil slice, got nil")
+				}
+				if len(got) != 0 {
+					t.Fatalf("expected 0 records, got %d", len(got))
+				}
+			},
+		},
+		{
+			name: "append single record, list returns it",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				r := record("disk", "am1")
+				s.Append("am1", r)
+				got := s.List("am1")
+				if len(got) != 1 {
+					t.Fatalf("expected 1 record, got %d", len(got))
+				}
+				if got[0].Mode != "disk" {
+					t.Errorf("expected mode disk, got %q", got[0].Mode)
+				}
+			},
+		},
+		{
+			name: "newest-first ordering",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				modes := []string{"disk", "github", "gitlab"}
+				for _, m := range modes {
+					s.Append("am1", record(m, "am1"))
+				}
+				got := s.List("am1")
+				if len(got) != 3 {
+					t.Fatalf("expected 3 records, got %d", len(got))
+				}
+				// Newest first: last appended should be at index 0.
+				if got[0].Mode != "gitlab" {
+					t.Errorf("expected gitlab first, got %q", got[0].Mode)
+				}
+				if got[2].Mode != "disk" {
+					t.Errorf("expected disk last, got %q", got[2].Mode)
+				}
+			},
+		},
+		{
+			name: "cap at 50, oldest evicted on overflow",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				// Append 51 records tagged with their index via CommitSHA.
+				for i := range 51 {
+					r := record("disk", "am1")
+					r.CommitSHA = string(rune('a' + i%26)) // just a tag
+					if i == 0 {
+						r.CommitSHA = "oldest"
+					}
+					if i == 50 {
+						r.CommitSHA = "newest"
+					}
+					s.Append("am1", r)
+				}
+				got := s.List("am1")
+				if len(got) != maxEntriesPerInstance {
+					t.Fatalf("expected %d records, got %d", maxEntriesPerInstance, len(got))
+				}
+				// First entry (newest) should be "newest".
+				if got[0].CommitSHA != "newest" {
+					t.Errorf("expected newest first, got %q", got[0].CommitSHA)
+				}
+				// "oldest" must have been evicted.
+				for _, rec := range got {
+					if rec.CommitSHA == "oldest" {
+						t.Error("oldest record should have been evicted")
+					}
+				}
+			},
+		},
+		{
+			name: "instances are isolated",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				s.Append("am1", record("disk", "am1"))
+				s.Append("am2", record("github", "am2"))
+				got1 := s.List("am1")
+				got2 := s.List("am2")
+				if len(got1) != 1 || got1[0].Mode != "disk" {
+					t.Errorf("am1: unexpected result %v", got1)
+				}
+				if len(got2) != 1 || got2[0].Mode != "github" {
+					t.Errorf("am2: unexpected result %v", got2)
+				}
+			},
+		},
+		{
+			name: "list returns a copy (mutations do not affect stored slice)",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				s.Append("am1", record("disk", "am1"))
+				got := s.List("am1")
+				got[0].Mode = "mutated"
+				again := s.List("am1")
+				if again[0].Mode == "mutated" {
+					t.Error("List returned a reference to internal slice; mutations leaked")
+				}
+			},
+		},
+		{
+			name: "concurrent append and list are race-free",
+			run: func(t *testing.T) {
+				t.Parallel()
+				s := NewStore()
+				var wg sync.WaitGroup
+				for range 20 {
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						s.Append("am1", record("disk", "am1"))
+					}()
+					go func() {
+						defer wg.Done()
+						_ = s.List("am1")
+					}()
+				}
+				wg.Wait()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.run)
+	}
+}

--- a/specs/_archive/009-config-builder-save-history/plan.md
+++ b/specs/_archive/009-config-builder-save-history/plan.md
@@ -1,0 +1,123 @@
+# Plan: Config Builder — Save & History
+
+**Status**: Approved
+**Spec**: specs/009-config-builder-save-history/spec.md
+
+## Open questions resolved
+
+| Q# | Decision |
+|----|----------|
+| Q1 — Save placement | **4th tab** ("Save & Deploy") in the Config Builder tab bar, consistent with Routing / Time Intervals / Receivers. |
+| Q2 — Actor label | **Role string** from the JWT (`config-editor`, `admin`). No `display_name` field introduced — this is a session-scoped log, not an audit trail. |
+| Q3 — History size | **Capped at 50 entries per Alertmanager instance**. Oldest entry evicted on overflow. The `raw_yaml` stored per record is typically < 10 KB; 50 × 10 KB = ~500 KB worst-case per instance, acceptable for in-memory session data. |
+| Q4 — GitOps pre-fill | **New `GET /api/config/gitops-defaults`** endpoint returning `{github_configured, gitlab_configured}`. The static config only stores tokens, not repo/branch/file, so only pusher availability is exposed. Fields remain empty and the user fills them at save time. |
+
+---
+
+## Architecture decisions
+
+### AD-1: New `internal/confighistory` package
+
+**Decision**: Introduce `internal/confighistory` as an independent package with a `Store` type — mirroring the `internal/incident` package pattern.
+
+**Rationale**: Keeps the history concern self-contained and testable in isolation. The handler layer depends on the store through a concrete type (not an interface), consistent with how `incident.Store` is used. No interface is added since there is no alternate implementation in scope.
+
+**Alternatives considered**: Embedding the history store directly in `ConfigHandler` — rejected because it would make the handler impossible to test without instantiating a full handler, and it blurs the package's single responsibility.
+
+---
+
+### AD-2: Actor extracted in the handler, not in the store
+
+**Decision**: The `Save` handler extracts the role from the JWT (`auth.ExtractBearerToken` + `svc.Validate`) and passes it as `Actor` when appending to the history store.
+
+**Rationale**: The store should be a dumb data structure with no auth dependency. The handler already has access to the auth service via middleware-populated context (or direct token extraction) and is the correct place to resolve identity.
+
+**Alternatives considered**: Passing the `*auth.Service` into the store — rejected, circular dependency risk and wrong separation of concerns.
+
+---
+
+### AD-3: History read endpoint requires `config-editor`, not `viewer`
+
+**Decision**: `GET /api/config/history` requires `config-editor` role, consistent with AC-8 and AC-12.
+
+**Rationale**: The history records contain `raw_yaml` snapshots of the full Alertmanager config. Exposing them to viewers would leak the full config to roles that can only see the routing tree (which is already read-only). The spec is explicit on this point.
+
+**Alternatives considered**: Returning a history list without `raw_yaml` for viewers — rejected because the spec scopes history to `config-editor` and the diff-on-expand feature requires the stored YAML.
+
+---
+
+### AD-4: `ConfigHandler` receives the history store via constructor injection
+
+**Decision**: Extend `NewConfigHandler` to accept a `*confighistory.Store`. The router creates one store per process and passes it in.
+
+**Rationale**: Matches how `NewIncidentsHandler` receives an `*incident.Store`. No global state.
+
+**Alternatives considered**: A package-level store singleton — rejected, untestable and violates the stateless-per-process philosophy.
+
+---
+
+### AD-5: GitOps defaults endpoint returns availability flags only
+
+**Decision**: `GET /api/config/gitops-defaults` returns `{github_configured: bool, gitlab_configured: bool}`. No repo/branch/file defaults are exposed because the static config does not store them.
+
+**Rationale**: The frontend needs to know which save modes to enable (AC-4). Token presence is the only signal available from the static config. This is a thin, stable contract.
+
+**Alternatives considered**: Omitting the endpoint and relying on the save error response to signal a misconfigured mode — rejected because it gives poor UX (the user would fill the form before learning the mode is unavailable).
+
+---
+
+## Impacted files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/confighistory/store.go` | Create | `SaveRecord` struct + `Store` (mutex-protected, 50-entry cap per instance) |
+| `internal/confighistory/store_test.go` | Create | Table-driven tests: append, cap eviction, list ordering, concurrent safety |
+| `internal/api/handlers/config.go` | Modify | Inject `*confighistory.Store`; `Save` appends record; add `History` and `GitopsDefaults` handlers |
+| `internal/api/router.go` | Modify | Instantiate `confighistory.Store`; pass to `NewConfigHandler`; register two new routes |
+| `web/src/routes/config/+layout.svelte` | Modify | Add "Save & Deploy" tab (Save icon, `/config/save` href) |
+| `web/src/routes/config/save/+page.svelte` | Create | Diff preview + save mode selector + save form + history list with expand-to-diff |
+| `web/src/lib/api/config.ts` | Modify | Add `fetchHistory()`, `fetchGitopsDefaults()` |
+| `web/src/lib/api/types.ts` | Modify | Add `SaveRecord` and `GitopsDefaults` types |
+
+---
+
+## Implementation phases
+
+### Phase 1 — Backend: history store
+
+- **Goal**: Implement `internal/confighistory` with a mutex-protected, per-instance capped store.
+- **Files**: `internal/confighistory/store.go`, `internal/confighistory/store_test.go`
+- **Deliverable**: `Store.Append(instanceName, SaveRecord)` and `Store.List(instanceName) []SaveRecord` pass all table-driven tests including the 50-entry eviction and race-detector clean run.
+
+### Phase 2 — Backend: API wiring
+
+- **Goal**: Extend `ConfigHandler` with the history store, wire new routes.
+- **Files**: `internal/api/handlers/config.go`, `internal/api/router.go`
+- **Changes**:
+  - `NewConfigHandler` gains `*confighistory.Store` parameter.
+  - `Save` handler: after a successful save, build a `confighistory.SaveRecord` (extract actor from JWT, capture `raw_yaml`, `mode`, `commit_sha`, `html_url`, `saved_at`) and call `store.Append`.
+  - Add `History` handler: `GET /api/config/history?instance=<name>` → `store.List(instance)` as JSON array.
+  - Add `GitopsDefaults` handler: `GET /api/config/gitops-defaults` → `{github_configured: bool, gitlab_configured: bool}` based on pusher nil-checks.
+  - Router: register both new routes under `requireConfigEditor`.
+
+### Phase 3 — Frontend: Save & Deploy page
+
+- **Goal**: Add the Save & Deploy tab and its full page: diff viewer, mode selector, form, and history list.
+- **Files**: `web/src/routes/config/+layout.svelte`, `web/src/routes/config/save/+page.svelte`, `web/src/lib/api/config.ts`, `web/src/lib/api/types.ts`
+- **Page behaviour**:
+  1. On mount: call `GET /api/config/gitops-defaults` to know which modes to enable; call `POST /api/config/diff` with the proposed YAML (passed via a shared store or URL state) and render `YamlDiffViewer`.
+  2. Mode selector: three options (disk / github / gitlab); disabled with tooltip if pusher not configured.
+  3. Conditional form fields: disk → file path; github/gitlab → repo, branch, file path, commit message, author name, author email.
+  4. Save button: disabled when `has_changes` is false or form invalid; calls `POST /api/config/save`; on success shows confirmation with optional commit link.
+  5. History section below the form: calls `GET /api/config/history?instance=<name>`; renders list with timestamp, mode badge, actor; each row has an expand button that calls `POST /api/config/diff` with the record's `raw_yaml` and renders a `YamlDiffViewer` inline.
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| The proposed YAML to diff is not easily available on the Save page (it's built up across three builder tabs) | Medium | The frontend config-builder pages already hold `raw_yaml` in local state; we introduce a lightweight Svelte writable store (`configDraftStore`) shared across the `/config/*` route group so the Save page can read the last assembled YAML. |
+| Race condition in `Store.Append` under concurrent saves | Low | `sync.Mutex` (write lock) on every append; `sync.RWMutex` for reads — same pattern as `incident.Store`. |
+| The 50-entry cap causes a save record to be evicted before a user reviews it | Low | Cap is per-instance; typical deployments make far fewer than 50 config saves per restart cycle. |
+| `auth.ExtractBearerToken` + `svc.Validate` in the Save handler adds a second token parse per request | Low | Negligible CPU cost; the middleware already validated the token. Alternative would be storing the role in context — acceptable future refactor but not needed here. |

--- a/specs/_archive/009-config-builder-save-history/review.md
+++ b/specs/_archive/009-config-builder-save-history/review.md
@@ -1,0 +1,87 @@
+# Review: Config Builder — Save & History
+
+**Date**: 2026-03-28
+**Verdict**: Ready to merge
+
+---
+
+## Tasks
+
+- [x] All tasks checked (9/9)
+
+---
+
+## Quality
+
+- [x] Tests pass: `go test ./... -race -count=1` → all 8 packages pass, race-detector clean
+- [x] Lint clean: `golangci-lint run ./...` → 0 issues
+- [x] TypeScript: `cd web && npx tsc --noEmit` → no errors
+- [x] Frontend tests: `cd web && npm test` → 140/140 pass
+
+---
+
+## Acceptance criteria
+
+- [x] **AC-1**: "Save & Deploy" tab present in Config Builder layout. Verified in `web/src/routes/config/+layout.svelte:19` — fourth tab with `href='/config/save'` and `Save` icon.
+
+- [x] **AC-2**: Save panel fetches diff via `POST /api/config/diff` and renders with `YamlDiffViewer`. Verified in `web/src/routes/config/save/+page.svelte:72` — `loadDiff()` calls `diffConfig()`, result fed into `<YamlDiffViewer>` at line 212.
+
+- [x] **AC-3**: Save button disabled and "No changes" message shown when `has_changes` is false. Verified: `canSave` derived value requires `!!diffResult?.has_changes` (line 49); "No changes to save." message rendered at line 294–296.
+
+- [x] **AC-4**: Mode selector shows disk/github/gitlab; unconfigured modes disabled with tooltip. Verified: `isModeDisabled()` (line 130) checks `gitopsDefaults`; `modeTooltip()` (line 137) provides the tooltip text; `title={tip}` + `disabled={disabled}` applied on each mode label (lines 228, 234).
+
+- [x] **AC-5**: For `disk` mode, file path field shown and pre-filled from `config_file_path` when set. Fixed: `configFilePath string` added to `alertmanager.Client`, populated in `NewClient`, exposed via `ConfigFilePath()` accessor. `GET /api/config/gitops-defaults?instance=<name>` now returns `disk_file_path`. Frontend `onMount` pre-fills `diskPath` from `d.disk_file_path` if the field is currently empty.
+
+- [x] **AC-6**: GitHub/GitLab fields shown (repo, branch, file path, commit message, author name, author email). No pre-fill needed — plan AD-5 explicitly resolved that the static config stores only tokens, not repo/branch/file, so fields start empty by design. All six fields verified in `+page.svelte` lines 260–279.
+
+- [x] **AC-7**: Successful save shows confirmation with mode and clickable commit link. Verified: success banner at lines 300–321 shows mode, truncated commit SHA, and `<a href={saveResult.html_url} target="_blank">View commit ↗</a>`.
+
+- [x] **AC-8**: `GET /api/config/history?instance=<name>` returns save records; requires `config-editor` role. Verified: `router.go:178` registers `r.With(requireConfigEditor).Get("/config/history", cfgH.History)`; handler at `config.go:265` calls `h.store.List(instance)`.
+
+- [x] **AC-9**: Each save record appended to in-memory history store with all required fields. Verified: `config.go:214–221` — `h.store.Append()` called with `SavedAt`, `Mode`, `Alertmanager`, `Actor` (from `auth.GetRole(r)`), `CommitSHA`, `HTMLURL`, `RawYAML`. Actor uses role from middleware context, not a second JWT parse.
+
+- [x] **AC-10**: History rows have expand button calling `POST /api/config/diff` with the saved `raw_yaml`; records store `raw_yaml`. Verified: `SaveRecord.RawYAML` stored on append; `toggleExpandDiff()` at line 146 calls `diffConfig(record.alertmanager, record.raw_yaml)`; diff rendered inline with `YamlDiffViewer`.
+
+- [x] **AC-11**: History is in-memory only, resets on restart. Verified: `confighistory` package has no persistence — `Store` is an in-memory `map`; `NewStore()` creates a fresh store on each `NewRouter()` call.
+
+- [x] **AC-12**: Save action requires `config-editor`; History endpoint requires `config-editor`. Verified: both in `router.go:177–178` via `requireConfigEditor`; `GitopsDefaults` also behind `requireConfigEditor` at line 179. Frontend additionally guards the save form and button behind `$canEditConfig`.
+
+- [x] **AC-13**: History store safe for concurrent access. Verified: `Store` uses `sync.RWMutex` — write lock in `Append()` (line 43), read lock in `List()` (line 57). Race-detector test `concurrent_append_and_list_are_race-free` passes.
+
+---
+
+## Architecture compliance
+
+| AD | Planned | Status |
+|----|---------|--------|
+| AD-1: `internal/confighistory` package | Created as planned | ✓ |
+| AD-2: Actor extracted in handler via `auth.GetRole(r)` | Implemented — no `*auth.Service` on handler | ✓ |
+| AD-3: History requires `config-editor` | Both endpoints gated | ✓ |
+| AD-4: Constructor injection `NewConfigHandler(..., store)` | Matches plan | ✓ |
+| AD-5: `GET /api/config/gitops-defaults` with availability flags only | Implemented | ✓ |
+| Plan: `configDraftStore` writable store | Created; all 3 builder pages write to it | ✓ |
+
+All planned files were created or modified as specified. T-3.4 and T-3.5 were merged into a single file pass (the history section is part of the same page) — no divergence from intent.
+
+---
+
+## Product docs
+
+- [x] `docs/features/config-builder.md` updated during T-2.3 with a new "Save & Deploy" section covering: diff preview, disk/GitHub/GitLab save modes, save history behaviour, and the 50-entry in-memory cap. Content is accurate.
+
+---
+
+## Constitution compliance
+
+- [x] **Stateless**: history store is session-scoped in-memory only, resets on restart. No database, no file I/O.
+- [x] **Single binary**: no new runtime dependencies introduced.
+- [x] **Security first**: CSRF/RBAC enforced — both new endpoints are behind `requireConfigEditor`. Frontend disables save button when `!$canEditConfig`.
+- [x] **RBAC by design**: role enforced in middleware, not in handlers. `auth.GetRole(r)` reads the already-validated role from context.
+- [x] **Error chain preservation**: new backend code uses `fmt.Errorf` where errors are wrapped (existing patterns in the file).
+- [x] **Tests**: table-driven, parallel, stdlib only — 7 sub-cases in `confighistory/store_test.go`.
+
+---
+
+## Verdict
+
+**Ready to merge** — All 13 ACs satisfied. Run `/ship` to create the PR.

--- a/specs/_archive/009-config-builder-save-history/spec.md
+++ b/specs/_archive/009-config-builder-save-history/spec.md
@@ -1,0 +1,50 @@
+# Spec: Config Builder — Save & History
+
+**Status**: Approved
+**Feature ID**: 009
+**Depends on**: 007, 008
+**GitHub issues**: #52
+
+## Context
+
+The Config Builder (features 007 and 008) lets users construct and validate an Alertmanager config through guided forms. However, there is no way to publish those changes — the assembled YAML lives only in the frontend until the user manually applies it. This feature adds the final step of the build → review → publish workflow: a diff preview, a save action (to disk or via GitOps), and an in-memory history of recent saves.
+
+The backend already implements `POST /api/config/save` (disk, GitHub, GitLab) and `POST /api/config/diff`. The `YamlDiffViewer` component exists. This feature wires everything together with a UI and adds the missing history layer.
+
+## User stories
+
+- As a config-editor, I want to see a diff of my proposed changes before committing them, so that I do not accidentally push unintended changes to Alertmanager.
+- As a config-editor, I want to save the config to disk or push it to a Git repository from the UI, so that I do not need CLI access to apply a change.
+- As a config-editor, I want to see a history of saves made since the last restart (with timestamp, mode, and commit SHA), so that I can track what was changed and when.
+- As a viewer, I want to see the save history (read-only) to understand recent changes applied to the configuration.
+
+## Acceptance criteria
+
+- [ ] AC-1: A "Save & Deploy" tab (or section) is present in the Config Builder layout and navigable from all existing builder tabs.
+- [ ] AC-2: The Save panel fetches the diff between the current live AM config and the proposed YAML via `POST /api/config/diff` and renders it with the existing `YamlDiffViewer` component before the user can confirm a save.
+- [ ] AC-3: When `has_changes` is false, the Save button is disabled and a "No changes" message is shown.
+- [ ] AC-4: The user can select save mode: `disk`, `github`, or `gitlab`. Modes whose backend pusher is not configured are disabled in the UI with a tooltip explaining why.
+- [ ] AC-5: For `disk` mode, a file path field is shown (pre-filled from the Alertmanager config's `config_file` path if available).
+- [ ] AC-6: For `github` / `gitlab` modes, GitOps fields (repo, branch, file path, commit message, author name, author email) are shown, pre-filled from the server config when available.
+- [ ] AC-7: A successful save triggers a confirmation with the mode and, for GitOps saves, a clickable link to the commit (`html_url`).
+- [ ] AC-8: The backend exposes `GET /api/config/history?instance=<name>` returning an array of save records; the endpoint requires `config-editor` role.
+- [ ] AC-9: Each save record written by `POST /api/config/save` is appended to the in-memory history store (scoped per Alertmanager instance) and contains: `saved_at` (RFC 3339), `mode`, `alertmanager`, `actor` (role from JWT), `commit_sha` (empty for disk), `html_url` (empty for disk).
+- [ ] AC-10: The history list in the frontend displays each record with timestamp, mode badge, actor, and a diff expand button; the diff on expand calls `POST /api/config/diff` with the live config and the YAML saved at that point — the save record must therefore also store the `raw_yaml`.
+- [ ] AC-11: History is in-memory only; it resets on process restart. No persistence is implemented in this feature.
+- [ ] AC-12: The Save action is gated behind the `config-editor` role in the backend (`RequireRole("config-editor")`); the History read endpoint requires at minimum `config-editor` role.
+- [ ] AC-13: The history store is protected by a mutex and safe for concurrent reads and writes.
+
+## Out of scope
+
+- Persistence of save history to disk or database (tracked in feature 024 / activity-log-persistence).
+- Webhook trigger from the Save UI (the backend already supports `webhook_url` in the payload; this feature does not expose it in the frontend).
+- Configuration of GitOps tokens from the UI (tokens are set in the static YAML config file).
+- Live reload of Alertmanager after a disk save (Alertmanager hot-reload is outside AlertLens scope).
+- Diffing against a previous history entry (the expand button always diffs against the current live config, not the state at save time).
+
+## Open questions
+
+- [ ] Q1: **Save button placement** — should "Save & Deploy" be a fourth tab in the Config Builder tab bar (alongside Routing, Time Intervals, Receivers), or a persistent "Save" button always visible in the layout header? A tab keeps the layout consistent but requires navigation; a header button is always accessible but adds visual weight. What is your preference?
+- [ ] Q2: **Actor label** — the JWT carries only a role (e.g., `config-editor`), not a username. Should the history record's `actor` field show the role string, or should we introduce an optional `display_name` field in the JWT / login flow for future readability?
+- [ ] Q3: **Diff stored in history** — storing the full `raw_yaml` per history entry means memory usage is proportional to config size × save count. Should we cap the in-memory history at a fixed size (e.g., last 50 saves), or leave it unbounded until restart?
+- [ ] Q4: **GitOps pre-fill** — the backend config holds static GitOps defaults (repo, branch, file path). Should the frontend fetch these defaults via a new `GET /api/config/gitops-defaults` endpoint, or is it acceptable to leave the fields empty (requiring the user to fill them on each save)?

--- a/specs/_archive/009-config-builder-save-history/tasks.md
+++ b/specs/_archive/009-config-builder-save-history/tasks.md
@@ -1,0 +1,141 @@
+# Tasks: Config Builder — Save & History
+
+**Status**: Ready
+**Total**: 9 tasks · 3 phases
+
+---
+
+## Phase 1 — History store (backend)
+
+- [x] **T-1.1**: Create `internal/confighistory` package with `SaveRecord` struct and mutex-protected `Store`
+  - Files: `internal/confighistory/store.go`
+  - `SaveRecord` fields: `SavedAt time.Time`, `Mode string`, `Alertmanager string`, `Actor string`, `CommitSHA string`, `HTMLURL string`, `RawYAML string`
+  - `Store` holds `mu sync.RWMutex` and `entries map[string][]SaveRecord` (key = alertmanager instance name)
+  - `Append(instance string, r SaveRecord)` — acquires write lock, appends, evicts oldest when `len > 50`
+  - `List(instance string) []SaveRecord` — acquires read lock, returns a copy of the slice (newest-first order: reverse before returning)
+  - Package-level doc comment: "Package confighistory implements an in-memory, per-instance save history for the Config Builder (feature 009). History resets on process restart."
+  - Test: `go test ./internal/confighistory/... -race -count=1`
+  - Developer writes: No
+
+- [x] **T-1.2**: Write table-driven tests for `internal/confighistory`
+  - Files: `internal/confighistory/store_test.go`
+  - Cases: append single record → List returns it; append 51 records → List returns 50 (oldest evicted); List on unknown instance → empty slice; concurrent Append + List passes race detector; newest-first ordering
+  - Test: `go test ./internal/confighistory/... -race -count=1`
+  - Developer writes: No
+
+---
+
+## Phase 2 — API layer
+
+- [x] **T-2.1**: Extend `ConfigHandler` with history store + add `History` handler
+  - Files: `internal/api/handlers/config.go`
+  - Add `store *confighistory.Store` field to `ConfigHandler`; update `NewConfigHandler(pool, gh, gl, store)` signature
+  - In `Save`: after the successful `writeJSON` at the end, extract the JWT role via `auth.ExtractBearerToken` + `h.svc.Validate` (requires adding `svc *auth.Service` field too, injected via constructor); build a `confighistory.SaveRecord` and call `h.store.Append(req.Alertmanager, record)`
+  - Add `History` handler: `GET /api/config/history?instance=<name>` → `writeJSON(w, map[string]any{"history": h.store.List(instance), "alertmanager": instance})`; returns empty array (not null) when no records exist
+  - Note: actor extraction follows the same pattern as `auth.ExtractBearerToken` used in middleware — no extra HTTP round-trip
+  - Test: `go build ./...` passes; handler covered by T-2.3
+  - Developer writes: No
+
+- [x] **T-2.2**: Add `GitopsDefaults` handler to `ConfigHandler`
+  - Files: `internal/api/handlers/config.go`
+  - Add `GitopsDefaults` handler: `GET /api/config/gitops-defaults` → `writeJSON(w, map[string]any{"github_configured": h.ghPusher != nil, "gitlab_configured": h.glPusher != nil})`
+  - No auth.Service needed here — the middleware already enforces config-editor role before the handler runs
+  - Test: `go build ./...` passes; handler covered by T-2.3
+  - Developer writes: No
+
+- [x] **T-2.3**: Wire new routes and history store in the router
+  - Files: `internal/api/router.go`
+  - Instantiate `confighistory.NewStore()` inside `NewRouter`
+  - Pass the store (and `authSvc`) to the updated `NewConfigHandler`
+  - Register under `requireConfigEditor`:
+    - `r.With(requireConfigEditor).Get("/config/history", cfgH.History)`
+    - `r.With(requireConfigEditor).Get("/config/gitops-defaults", cfgH.GitopsDefaults)`
+  - Ensure import of `internal/confighistory` is added
+  - Test: `go build ./...` + `go test ./internal/api/... -race -count=1`
+  - Developer writes: No
+
+---
+
+## Phase 3 — Frontend
+
+- [x] **T-3.1**: Add types and API client functions
+  - Files: `web/src/lib/api/types.ts`, `web/src/lib/api/config.ts`
+  - In `types.ts` add:
+    ```ts
+    export interface SaveRecord {
+      saved_at: string;        // RFC 3339
+      mode: 'disk' | 'github' | 'gitlab';
+      alertmanager: string;
+      actor: string;
+      commit_sha: string;
+      html_url: string;
+      raw_yaml: string;
+    }
+    export interface GitopsDefaults {
+      github_configured: boolean;
+      gitlab_configured: boolean;
+    }
+    ```
+  - In `config.ts` add:
+    ```ts
+    export function fetchHistory(instance: string): Promise<{ history: SaveRecord[]; alertmanager: string }> { ... }
+    export function fetchGitopsDefaults(): Promise<GitopsDefaults> { ... }
+    ```
+  - Test: `cd web && npx tsc --noEmit`
+  - Developer writes: No
+
+- [x] **T-3.2**: Add shared `configDraftStore` Svelte writable store
+  - Files: `web/src/lib/stores/configDraft.ts`
+  - Export a writable store: `export const configDraftStore = writable<{ instance: string; rawYaml: string } | null>(null)`
+  - The existing builder pages (routing, receivers, time-intervals) should `import { configDraftStore } from '$lib/stores/configDraft'` and call `configDraftStore.set({ instance, rawYaml })` after each successful mutation (the `raw_yaml` field already returned by every builder endpoint)
+  - Modify three existing pages to call `configDraftStore.set(...)` after any successful upsert/delete/set-route response
+  - Files also modified: `web/src/routes/config/routing/+page.svelte`, `web/src/routes/config/receivers/+page.svelte`, `web/src/routes/config/time-intervals/+page.svelte`
+  - Test: `cd web && npx tsc --noEmit` + manual: edit a receiver, navigate to Save & Deploy, verify YAML appears in diff
+  - Developer writes: No
+
+- [x] **T-3.3**: Add "Save & Deploy" tab to Config Builder layout
+  - Files: `web/src/routes/config/+layout.svelte`
+  - Import `Save` icon from `lucide-svelte`
+  - Add `{ href: '/config/save', label: 'Save & Deploy', icon: Save }` as the 4th entry in `tabs`
+  - Test: `cd web && npx tsc --noEmit` + visual: tab appears in the tab bar
+  - Developer writes: No
+
+- [x] **T-3.4**: Create the Save & Deploy page — diff preview and save form
+  - Files: `web/src/routes/config/save/+page.svelte`
+  - On mount:
+    1. Call `fetchGitopsDefaults()` to know which modes to enable
+    2. If `$configDraftStore` is non-null, call `diffConfig(instance, rawYaml)` and render `YamlDiffViewer` with the result
+    3. If `$configDraftStore` is null, show an info message: "No pending changes. Edit the routing, receivers, or time intervals first."
+  - Mode selector: radio/button group for `disk` / `github` / `gitlab`; disabled with `title` tooltip when the corresponding pusher is not configured
+  - Conditional form fields:
+    - `disk`: single text input for file path (label "Config file path")
+    - `github` / `gitlab`: inputs for repo, branch, file path, commit message, author name, author email
+  - Save button: disabled when `has_changes === false` or required fields are empty; on click calls `saveConfig(...)` from `$lib/api/config`
+  - On success: show a success banner with mode and, for GitOps modes, a link (`<a href={html_url} target="_blank">`) to the commit
+  - On error: show an error banner with the message
+  - Test: `cd web && npx tsc --noEmit` + manual flow (see T-3.5)
+  - Developer writes: No
+
+- [x] **T-3.5**: Add history list to the Save & Deploy page
+  - Files: `web/src/routes/config/save/+page.svelte`
+  - Below the save form, add a "Save History" section
+  - On mount (alongside the diff): call `fetchHistory(instance)` and store results reactively
+  - Refresh history after each successful save
+  - Render each `SaveRecord` as a row: formatted `saved_at` timestamp, `mode` badge (colour-coded: disk=gray, github=blue, gitlab=orange), `actor` label
+  - Each row has an "Expand diff" toggle button; on expand, call `diffConfig(instance, record.raw_yaml)` (lazy — only on first expand) and render a `YamlDiffViewer` inline below the row
+  - When history is empty: show "No saves recorded since last restart."
+  - Test: `cd web && npm test` (unit) + `cd web && npx tsc --noEmit` + manual: perform a save and verify the new record appears at the top of the list
+  - Developer writes: No
+
+---
+
+## Verification checklist (run after all tasks)
+
+```bash
+go build ./...
+go test ./... -race -count=1
+cd web && npx tsc --noEmit
+cd web && npm test
+```
+
+All AC-1 through AC-13 from the spec must be manually verified before `/review`.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -21,7 +21,7 @@ _Last updated: 2026-03-19_
 |-----|---------|-------------|--------|------------|--------|
 | 007 | config-builder-routing | CRUD for routing tree via guided forms + YAML preview | [x] | 006 | #50 |
 | 008 | config-builder-receivers | CRUD for receivers and time intervals | [x] | 007 | #51 |
-| 009 | config-builder-save-history | Save to Alertmanager + change history / diff view | [~] | 007 008 | #52 |
+| 009 | config-builder-save-history | Save to Alertmanager + change history / diff view | [x] | 007 008 | #52 |
 | 010 | auth-rbac-fixes | Fix default role bug, login UX, role validation at startup | [x] | 006 | #87 #88 #89 #90 #91 #92 |
 | 011 | activity-log | Requalify incident tracking as Session Activity Log (ADR-009) | [ ] | 006 | #97 |
 

--- a/web/src/lib/api/config.ts
+++ b/web/src/lib/api/config.ts
@@ -1,5 +1,5 @@
 import { api } from './client';
-import type { ConfigResponse, ValidationResult, SaveConfigRequest } from './types';
+import type { ConfigResponse, GitopsDefaults, SaveConfigRequest, SaveRecord, ValidationResult } from './types';
 
 export function fetchConfig(instance?: string): Promise<ConfigResponse> {
 	const q = instance ? `?instance=${encodeURIComponent(instance)}` : '';
@@ -28,4 +28,15 @@ export function saveConfig(req: SaveConfigRequest): Promise<{
 	warning?: string;
 }> {
 	return api.post('/config/save', req);
+}
+
+export function fetchHistory(
+	instance: string
+): Promise<{ history: SaveRecord[]; alertmanager: string }> {
+	return api.get(`/config/history?instance=${encodeURIComponent(instance)}`);
+}
+
+export function fetchGitopsDefaults(instance?: string): Promise<GitopsDefaults> {
+	const q = instance ? `?instance=${encodeURIComponent(instance)}` : '';
+	return api.get(`/config/gitops-defaults${q}`);
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -364,6 +364,25 @@ export interface BuilderReceiverRoutesResponse {
 	referenced_by: BuilderReceiverRouteRef[];
 }
 
+// ─── Config Save History types (feature 009) ─────────────────────────────────
+
+export interface SaveRecord {
+	saved_at: string; // RFC 3339
+	mode: 'disk' | 'github' | 'gitlab';
+	alertmanager: string;
+	actor: string;
+	commit_sha: string;
+	html_url: string;
+	raw_yaml: string;
+}
+
+export interface GitopsDefaults {
+	github_configured: boolean;
+	gitlab_configured: boolean;
+	/** Local file path from config_file_path for the queried instance; empty string if not set. */
+	disk_file_path: string;
+}
+
 export interface SaveConfigRequest {
 	alertmanager: string;
 	raw_yaml: string;

--- a/web/src/lib/stores/configDraft.ts
+++ b/web/src/lib/stores/configDraft.ts
@@ -1,0 +1,12 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Holds the most-recently assembled proposed Alertmanager config YAML from any
+ * of the Config Builder tabs (Routing, Receivers, Time Intervals).
+ *
+ * The Save & Deploy page reads this to pre-populate its diff view so the user
+ * can review and publish the assembled changes without re-entering them.
+ *
+ * Set to null when no changes have been assembled since the page was loaded.
+ */
+export const configDraftStore = writable<{ instance: string; rawYaml: string } | null>(null);

--- a/web/src/routes/config/+layout.svelte
+++ b/web/src/routes/config/+layout.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
-	import { Settings, GitBranch, Clock, Radio } from 'lucide-svelte';
+	import { Settings, GitBranch, Clock, Radio, Save } from 'lucide-svelte';
 
 	let { children } = $props();
 
@@ -15,7 +15,8 @@
 	const tabs = [
 		{ href: '/config/routing',         label: 'Routing',         icon: GitBranch },
 		{ href: '/config/time-intervals',  label: 'Time Intervals',  icon: Clock },
-		{ href: '/config/receivers',       label: 'Receivers',       icon: Radio }
+		{ href: '/config/receivers',       label: 'Receivers',       icon: Radio },
+		{ href: '/config/save',            label: 'Save & Deploy',   icon: Save }
 	];
 </script>
 

--- a/web/src/routes/config/receivers/+page.svelte
+++ b/web/src/routes/config/receivers/+page.svelte
@@ -14,6 +14,7 @@
 	import YamlDiffViewer from '$lib/components/config/YamlDiffViewer.svelte';
 	import { instances } from '$lib/stores/alerts';
 	import { canEditConfig } from '$lib/stores/auth';
+	import { configDraftStore } from '$lib/stores/configDraft';
 	import { toast } from 'svelte-sonner';
 	import { Plus, Trash2, Eye, Save, Lock } from 'lucide-svelte';
 
@@ -97,8 +98,10 @@
 		if (!editing) return;
 		upserting = true;
 		try {
-			await upsertReceiver(editing.name, editing, selectedInstance || undefined);
+			const result = await upsertReceiver(editing.name, editing, selectedInstance || undefined);
 			toast.success(`Receiver "${editing.name}" saved`);
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: result.raw_yaml });
 			await load();
 		} catch (e) {
 			toast.error('Save error: ' + (e instanceof Error ? e.message : ''));
@@ -123,10 +126,12 @@
 
 	async function confirmDelete(name: string) {
 		try {
-			await deleteReceiver(name, selectedInstance || undefined);
+			const result = await deleteReceiver(name, selectedInstance || undefined);
 			toast.success(`Receiver "${name}" deleted`);
 			if (editing?.name === name) editing = null;
 			deleteGuard = null;
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: result.raw_yaml });
 			await load();
 		} catch (e) {
 			toast.error('Delete error: ' + (e instanceof Error ? e.message : ''));
@@ -143,6 +148,8 @@
 			pendingYaml = exported.raw_yaml;
 			diffResult = await diffConfig(selectedInstance || '', exported.raw_yaml);
 			step = 'diff';
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: exported.raw_yaml });
 		} catch (e) {
 			toast.error('Diff error: ' + (e instanceof Error ? e.message : ''));
 		}

--- a/web/src/routes/config/routing/+page.svelte
+++ b/web/src/routes/config/routing/+page.svelte
@@ -9,6 +9,7 @@
 	import RouteNodeEditor, { type RouteFormNode, emptyNode } from '$lib/components/config/RouteNodeEditor.svelte';
 	import { instances } from '$lib/stores/alerts';
 	import { canEditConfig } from '$lib/stores/auth';
+	import { configDraftStore } from '$lib/stores/configDraft';
 	import { toast } from 'svelte-sonner';
 	import type { RouteNode } from '$lib/api/types';
 	import { Save, Eye, AlertTriangle, FormInput, Code, Lock } from 'lucide-svelte';
@@ -131,6 +132,8 @@
 			pendingYaml = yamlToUse;
 			diffResult = await diffConfig(selectedInstance || '', yamlToUse);
 			step = 'diff';
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: yamlToUse });
 		} catch (e) {
 			toast.error('Diff error: ' + (e instanceof Error ? e.message : ''));
 		}

--- a/web/src/routes/config/save/+page.svelte
+++ b/web/src/routes/config/save/+page.svelte
@@ -1,0 +1,409 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { diffConfig, saveConfig, fetchGitopsDefaults, fetchHistory } from '$lib/api/config';
+	import type { GitopsDefaults, SaveRecord } from '$lib/api/types';
+	import { configDraftStore } from '$lib/stores/configDraft';
+	import { instances } from '$lib/stores/alerts';
+	import { canEditConfig } from '$lib/stores/auth';
+	import YamlDiffViewer from '$lib/components/config/YamlDiffViewer.svelte';
+	import { toast } from 'svelte-sonner';
+	import { Save, CheckCircle, AlertTriangle, Lock, ChevronDown, ChevronRight } from 'lucide-svelte';
+
+	// ─── GitOps availability ──────────────────────────────────────────────────
+	let gitopsDefaults = $state<GitopsDefaults | null>(null);
+
+	// ─── Diff state ───────────────────────────────────────────────────────────
+	let diffResult = $state<{ diff: string; has_changes: boolean } | null>(null);
+	let diffLoading = $state(false);
+
+	// ─── Save form state ──────────────────────────────────────────────────────
+	let saving = $state(false);
+	let saveMode = $state<'disk' | 'github' | 'gitlab'>('disk');
+	let diskPath = $state('');
+	let gitRepo = $state('');
+	let gitBranch = $state('main');
+	let gitFilePath = $state('alertmanager.yml');
+	let gitCommitMessage = $state('');
+	let gitAuthorName = $state('');
+	let gitAuthorEmail = $state('');
+
+	// ─── Result banners ───────────────────────────────────────────────────────
+	let saveResult = $state<{
+		mode: string;
+		commit_sha?: string;
+		html_url?: string;
+		warning?: string;
+	} | null>(null);
+	let saveError = $state<string | null>(null);
+
+	// ─── History ──────────────────────────────────────────────────────────────
+	let history = $state<SaveRecord[]>([]);
+	let expandedDiffs = $state<Record<number, { diff: string; has_changes: boolean } | null>>({});
+	let expandLoading = $state<Record<number, boolean>>({});
+
+	// ─── Derived ─────────────────────────────────────────────────────────────
+	const draft = $derived($configDraftStore);
+
+	const canSave = $derived(
+		!!draft &&
+		!!diffResult?.has_changes &&
+		!saving &&
+		$canEditConfig &&
+		(saveMode === 'disk'
+			? !!diskPath
+			: !!gitRepo && !!gitBranch && !!gitFilePath)
+	);
+
+	// Auto-refresh diff whenever draft changes.
+	$effect(() => {
+		const d = $configDraftStore;
+		if (d) {
+			loadDiff(d.instance, d.rawYaml);
+		} else {
+			diffResult = null;
+		}
+	});
+
+	// ─── Functions ────────────────────────────────────────────────────────────
+
+	async function loadDiff(instance: string, rawYaml: string) {
+		diffLoading = true;
+		try {
+			diffResult = await diffConfig(instance, rawYaml);
+		} catch (e) {
+			toast.error('Diff error: ' + (e instanceof Error ? e.message : ''));
+		} finally {
+			diffLoading = false;
+		}
+	}
+
+	async function loadHistory(instance: string) {
+		try {
+			const resp = await fetchHistory(instance);
+			history = resp.history;
+		} catch {
+			// Non-fatal — history section stays empty.
+		}
+	}
+
+	async function save() {
+		if (!draft) return;
+		saving = true;
+		saveResult = null;
+		saveError = null;
+		try {
+			const result = await saveConfig({
+				alertmanager: draft.instance,
+				raw_yaml: draft.rawYaml,
+				save_mode: saveMode,
+				disk_options: saveMode === 'disk' ? { file_path: diskPath } : undefined,
+				git_options: saveMode !== 'disk'
+					? {
+						repo: gitRepo,
+						branch: gitBranch,
+						file_path: gitFilePath,
+						commit_message: gitCommitMessage || undefined,
+						author_name: gitAuthorName || undefined,
+						author_email: gitAuthorEmail || undefined
+					}
+					: undefined
+			});
+			saveResult = {
+				mode: result.mode,
+				commit_sha: result.commit_sha,
+				html_url: result.html_url,
+				warning: result.warning
+			};
+			toast.success('Configuration saved successfully');
+			// Refresh diff and history after a successful save.
+			await Promise.all([
+				loadDiff(draft.instance, draft.rawYaml),
+				loadHistory(draft.instance)
+			]);
+		} catch (e) {
+			saveError = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			saving = false;
+		}
+	}
+
+	function isModeDisabled(mode: 'disk' | 'github' | 'gitlab'): boolean {
+		if (!gitopsDefaults) return false; // unknown — allow, server will validate
+		if (mode === 'github') return !gitopsDefaults.github_configured;
+		if (mode === 'gitlab') return !gitopsDefaults.gitlab_configured;
+		return false; // disk is always available
+	}
+
+	function modeTooltip(mode: 'disk' | 'github' | 'gitlab'): string {
+		if (mode === 'github' && gitopsDefaults && !gitopsDefaults.github_configured) {
+			return 'GitHub token not configured in alertlens.yaml';
+		}
+		if (mode === 'gitlab' && gitopsDefaults && !gitopsDefaults.gitlab_configured) {
+			return 'GitLab token not configured in alertlens.yaml';
+		}
+		return '';
+	}
+
+	async function toggleExpandDiff(idx: number, record: SaveRecord) {
+		if (expandedDiffs[idx] !== undefined) {
+			// Collapse
+			const next = { ...expandedDiffs };
+			delete next[idx];
+			expandedDiffs = next;
+			return;
+		}
+		expandLoading = { ...expandLoading, [idx]: true };
+		try {
+			const result = await diffConfig(record.alertmanager, record.raw_yaml);
+			expandedDiffs = { ...expandedDiffs, [idx]: result };
+		} catch {
+			expandedDiffs = { ...expandedDiffs, [idx]: null };
+		} finally {
+			const next = { ...expandLoading };
+			delete next[idx];
+			expandLoading = next;
+		}
+	}
+
+	function formatTime(isoString: string): string {
+		try {
+			return new Date(isoString).toLocaleString();
+		} catch {
+			return isoString;
+		}
+	}
+
+	const modeBadgeClass: Record<string, string> = {
+		disk:   'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+		github: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+		gitlab: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300'
+	};
+
+	onMount(async () => {
+		// Load GitOps defaults and initial history in parallel.
+		const currentInstance = $configDraftStore?.instance ?? $instances[0]?.name ?? '';
+		await Promise.all([
+			fetchGitopsDefaults(currentInstance).then(d => {
+				gitopsDefaults = d;
+				// Pre-fill the disk path from the instance's config_file_path if not already set.
+				if (!diskPath && d.disk_file_path) {
+					diskPath = d.disk_file_path;
+				}
+			}).catch(() => {}),
+			loadHistory(currentInstance)
+		]);
+	});
+</script>
+
+<div class="mt-4 space-y-6">
+
+	{#if !$canEditConfig}
+		<div class="flex items-center gap-2 p-3 rounded-lg border bg-muted/30 text-sm text-muted-foreground">
+			<Lock class="h-4 w-4 shrink-0" />
+			You need the <strong class="mx-1 text-foreground">config-editor</strong> role to save configurations.
+		</div>
+	{/if}
+
+	<!-- ─── Diff preview ─────────────────────────────────────────────────── -->
+	<div class="space-y-2">
+		<h2 class="font-semibold">Pending changes</h2>
+
+		{#if !draft}
+			<div class="p-4 rounded-lg border bg-muted/30 text-sm text-muted-foreground text-center">
+				No pending changes. Edit the routing, receivers, or time intervals first.
+			</div>
+		{:else if diffLoading}
+			<div class="py-6 text-center text-muted-foreground animate-pulse text-sm">Computing diff…</div>
+		{:else if diffResult}
+			<YamlDiffViewer diff={diffResult.diff} hasChanges={diffResult.has_changes} />
+		{/if}
+	</div>
+
+	<!-- ─── Save form ───────────────────────────────────────────────────── -->
+	{#if $canEditConfig && draft}
+		<div class="rounded-lg border bg-card p-4 space-y-4">
+			<h2 class="font-semibold">Save mode</h2>
+
+			<!-- Mode selector -->
+			<div class="flex gap-4">
+				{#each (['disk', 'github', 'gitlab'] as const) as mode}
+					{@const disabled = isModeDisabled(mode)}
+					{@const tip = modeTooltip(mode)}
+					<label
+						class="flex items-center gap-1.5 {disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}"
+						title={tip}
+					>
+						<input
+							type="radio"
+							bind:group={saveMode}
+							value={mode}
+							disabled={disabled}
+						/>
+						<span class="text-sm capitalize">{mode}</span>
+					</label>
+				{/each}
+			</div>
+
+			<!-- Conditional fields -->
+			{#if saveMode === 'disk'}
+				<div class="space-y-1">
+					<label class="text-xs font-medium text-muted-foreground">Config file path</label>
+					<input
+						bind:value={diskPath}
+						placeholder="/etc/alertmanager/alertmanager.yml"
+						class="w-full px-3 py-2 rounded border bg-background text-sm"
+					/>
+				</div>
+			{:else}
+				<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					<div class="space-y-1 sm:col-span-2">
+						<label class="text-xs font-medium text-muted-foreground">Repository</label>
+						<input
+							bind:value={gitRepo}
+							placeholder={saveMode === 'github' ? 'owner/repo' : 'namespace/project'}
+							class="w-full px-3 py-2 rounded border bg-background text-sm"
+						/>
+					</div>
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-muted-foreground">Branch</label>
+						<input bind:value={gitBranch} placeholder="main" class="w-full px-3 py-2 rounded border bg-background text-sm" />
+					</div>
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-muted-foreground">File path</label>
+						<input bind:value={gitFilePath} placeholder="alertmanager.yml" class="w-full px-3 py-2 rounded border bg-background text-sm" />
+					</div>
+					<div class="space-y-1 sm:col-span-2">
+						<label class="text-xs font-medium text-muted-foreground">Commit message</label>
+						<input bind:value={gitCommitMessage} placeholder="chore: update alertmanager config" class="w-full px-3 py-2 rounded border bg-background text-sm" />
+					</div>
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-muted-foreground">Author name</label>
+						<input bind:value={gitAuthorName} placeholder="AlertLens" class="w-full px-3 py-2 rounded border bg-background text-sm" />
+					</div>
+					<div class="space-y-1">
+						<label class="text-xs font-medium text-muted-foreground">Author email</label>
+						<input bind:value={gitAuthorEmail} placeholder="alertlens@example.com" class="w-full px-3 py-2 rounded border bg-background text-sm" />
+					</div>
+				</div>
+			{/if}
+
+			<!-- Save button -->
+			<div class="flex items-center gap-3 pt-1">
+				<button
+					onclick={save}
+					disabled={!canSave}
+					class="flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 text-sm disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+				>
+					<Save class="h-4 w-4" />
+					{saving ? 'Saving…' : 'Save & Deploy'}
+				</button>
+				{#if diffResult && !diffResult.has_changes}
+					<span class="text-sm text-muted-foreground">No changes to save.</span>
+				{/if}
+			</div>
+
+			<!-- Success banner -->
+			{#if saveResult}
+				<div class="flex items-start gap-2 p-3 rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-sm">
+					<CheckCircle class="h-4 w-4 text-green-600 dark:text-green-400 shrink-0 mt-0.5" />
+					<div>
+						<p class="font-medium text-green-800 dark:text-green-300">
+							Saved via <span class="capitalize">{saveResult.mode}</span>
+							{#if saveResult.commit_sha}
+								— commit <code class="font-mono text-xs">{saveResult.commit_sha.slice(0, 8)}</code>
+							{/if}
+						</p>
+						{#if saveResult.html_url}
+							<a
+								href={saveResult.html_url}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-xs text-green-700 dark:text-green-400 underline hover:no-underline"
+							>
+								View commit ↗
+							</a>
+						{/if}
+						{#if saveResult.warning}
+							<p class="text-xs text-yellow-700 dark:text-yellow-400 mt-1">⚠ {saveResult.warning}</p>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			<!-- Error banner -->
+			{#if saveError}
+				<div class="flex items-start gap-2 p-3 rounded-md bg-destructive/10 border border-destructive/30 text-sm">
+					<AlertTriangle class="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+					<p class="text-destructive">{saveError}</p>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- ─── Save History ─────────────────────────────────────────────────── -->
+	<div class="space-y-2">
+		<h2 class="font-semibold">Save History</h2>
+		<p class="text-xs text-muted-foreground">In-memory since last restart · up to 50 saves per instance · newest first</p>
+
+		{#if history.length === 0}
+			<div class="p-4 rounded-lg border bg-muted/30 text-sm text-muted-foreground text-center">
+				No saves recorded since last restart.
+			</div>
+		{:else}
+			<div class="space-y-2">
+				{#each history as record, idx}
+					<div class="rounded-lg border bg-card overflow-hidden">
+						<!-- Row header -->
+						<div class="flex items-center gap-3 px-4 py-3">
+							<span class="text-xs text-muted-foreground shrink-0">{formatTime(record.saved_at)}</span>
+							<span class="px-2 py-0.5 rounded-full text-xs font-medium {modeBadgeClass[record.mode] ?? modeBadgeClass.disk}">
+								{record.mode}
+							</span>
+							<span class="text-xs text-muted-foreground">{record.actor}</span>
+							{#if record.html_url}
+								<a
+									href={record.html_url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-xs text-primary underline hover:no-underline ml-auto shrink-0"
+								>
+									commit ↗
+								</a>
+							{/if}
+							<button
+								onclick={() => toggleExpandDiff(idx, record)}
+								disabled={expandLoading[idx]}
+								class="flex items-center gap-1 ml-auto shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+							>
+								{#if expandLoading[idx]}
+									<span class="animate-pulse">Loading…</span>
+								{:else if expandedDiffs[idx] !== undefined}
+									<ChevronDown class="h-3.5 w-3.5" />
+									Collapse diff
+								{:else}
+									<ChevronRight class="h-3.5 w-3.5" />
+									Expand diff
+								{/if}
+							</button>
+						</div>
+
+						<!-- Inline diff (lazy-loaded on first expand) -->
+						{#if expandedDiffs[idx] !== undefined}
+							<div class="border-t px-4 py-3">
+								{#if expandedDiffs[idx] === null}
+									<p class="text-xs text-destructive">Failed to load diff.</p>
+								{:else}
+									<YamlDiffViewer
+										diff={expandedDiffs[idx]!.diff}
+										hasChanges={expandedDiffs[idx]!.has_changes}
+									/>
+								{/if}
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+</div>

--- a/web/src/routes/config/time-intervals/+page.svelte
+++ b/web/src/routes/config/time-intervals/+page.svelte
@@ -11,6 +11,7 @@
 	import YamlDiffViewer from '$lib/components/config/YamlDiffViewer.svelte';
 	import { instances } from '$lib/stores/alerts';
 	import { canEditConfig } from '$lib/stores/auth';
+	import { configDraftStore } from '$lib/stores/configDraft';
 	import { toast } from 'svelte-sonner';
 	import { Plus, Trash2, Save, Eye, Lock } from 'lucide-svelte';
 
@@ -96,9 +97,11 @@
 			return;
 		}
 		try {
-			await deleteTimeInterval(name, selectedInstance || undefined);
+			const result = await deleteTimeInterval(name, selectedInstance || undefined);
 			toast.success(`Time interval "${name}" deleted`);
 			if (editingIdx === idx) editingIdx = null;
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: result.raw_yaml });
 			await load();
 		} catch (e) {
 			toast.error('Delete error: ' + (e instanceof Error ? e.message : ''));
@@ -169,6 +172,8 @@
 			pendingYaml = exported.raw_yaml;
 			diffResult = await diffConfig(selectedInstance || '', exported.raw_yaml);
 			step = 'diff';
+			// Share the assembled YAML with the Save & Deploy tab.
+			configDraftStore.set({ instance: selectedInstance, rawYaml: exported.raw_yaml });
 		} catch (e) {
 			toast.error('Diff error: ' + (e instanceof Error ? e.message : ''));
 		}


### PR DESCRIPTION
## Summary

- Adds a **Save & Deploy** fourth tab to the Config Builder with a unified diff preview, save mode selector (disk / GitHub / GitLab), and per-instance in-memory save history
- New `internal/confighistory` package: mutex-protected, 50-entry-capped store mirroring the `incident` package pattern
- Actor for history records is extracted from the request context (`auth.GetRole`) set by the `RequireRole` middleware — no second JWT parse
- A shared `configDraftStore` Svelte writable is written by each builder tab (routing, receivers, time-intervals) after every mutation so the Save & Deploy page always shows the latest assembled YAML
- `GET /api/config/gitops-defaults?instance=<name>` returns pusher availability and the instance's `config_file_path` to pre-fill the disk path field

## Changes

**Backend**
- `internal/confighistory/store.go` — new package: `SaveRecord` + `Store` (RWMutex, 50-entry eviction, newest-first `List`)
- `internal/confighistory/store_test.go` — 7 table-driven parallel tests including race-detector case
- `internal/alertmanager/client.go` — add `configFilePath` field + `ConfigFilePath()` accessor
- `internal/api/handlers/config.go` — inject `*confighistory.Store`; `Save` appends record; add `History` and `GitopsDefaults` handlers
- `internal/api/router.go` — instantiate store, pass to handler, register `GET /config/history` and `GET /config/gitops-defaults`

**Frontend**
- `web/src/lib/api/types.ts` — add `SaveRecord`, `GitopsDefaults` types
- `web/src/lib/api/config.ts` — add `fetchHistory()`, `fetchGitopsDefaults(instance?)`
- `web/src/lib/stores/configDraft.ts` — new `configDraftStore` writable
- `web/src/routes/config/+layout.svelte` — add "Save & Deploy" tab
- `web/src/routes/config/save/+page.svelte` — new page: diff viewer, mode selector, save form, history list with lazy diff-on-expand
- `web/src/routes/config/receivers/+page.svelte` — write to `configDraftStore` after upsert/delete/previewDiff
- `web/src/routes/config/routing/+page.svelte` — write to `configDraftStore` after previewDiff
- `web/src/routes/config/time-intervals/+page.svelte` — write to `configDraftStore` after delete/previewDiff

**Docs**
- `docs/features/config-builder.md` — rewrite "Saving Changes" → new "Save & Deploy" section

## Spec

`specs/_archive/009-config-builder-save-history/spec.md`

## Acceptance criteria

- [ ] AC-1: A "Save & Deploy" tab is present in the Config Builder layout and navigable from all existing builder tabs
- [ ] AC-2: The Save panel fetches the diff via `POST /api/config/diff` and renders it with `YamlDiffViewer` before the user can confirm a save
- [ ] AC-3: When `has_changes` is false, the Save button is disabled and a "No changes" message is shown
- [ ] AC-4: The user can select save mode: disk, github, or gitlab. Modes whose backend pusher is not configured are disabled with a tooltip
- [ ] AC-5: For disk mode, a file path field is shown, pre-filled from the instance's `config_file_path` when set
- [ ] AC-6: For github/gitlab modes, GitOps fields (repo, branch, file path, commit message, author name, author email) are shown
- [ ] AC-7: A successful save shows a confirmation with mode and, for GitOps saves, a clickable link to the commit
- [ ] AC-8: `GET /api/config/history?instance=<name>` returns save records; requires config-editor role
- [ ] AC-9: Each save record contains: saved_at, mode, alertmanager, actor (role), commit_sha, html_url, raw_yaml
- [ ] AC-10: The expand button in each history row calls `POST /api/config/diff` with the saved raw_yaml and renders a diff inline
- [ ] AC-11: History is in-memory only; resets on process restart
- [ ] AC-12: Save action gated behind config-editor role; History endpoint requires config-editor
- [ ] AC-13: History store protected by a mutex and safe for concurrent reads and writes

## Test plan

- [ ] `go test ./... -race -count=1` passes
- [ ] `golangci-lint run ./...` → 0 issues
- [ ] `cd web && npx tsc --noEmit` → no errors
- [ ] `cd web && npm test` → 140 tests pass
- [ ] Navigate to Config Builder → "Save & Deploy" tab appears
- [ ] Edit a receiver → navigate to Save & Deploy → diff is shown automatically
- [ ] Mode selector: disable GitHub/GitLab when tokens are not configured; disk path pre-filled when `config_file_path` is set
- [ ] Save to disk → success banner appears; no commit link shown
- [ ] Save via GitHub/GitLab → success banner with clickable commit link
- [ ] History list: new row appears after each save; "Expand diff" loads inline diff lazily

## Closes

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)